### PR TITLE
Compatible with new event dates

### DIFF
--- a/src/containers/Dashboard/components/ActivityPanel/index.js
+++ b/src/containers/Dashboard/components/ActivityPanel/index.js
@@ -15,9 +15,12 @@ import { actions } from 'public-modules/Activity';
 class ActivityPanelComponent extends React.Component {
   renderActivity = list => {
     return map(activity => {
-      const { created, data, notification } = activity;
+      const { data, notification } = activity;
       const { bounty_title, link } = data;
-      const { notification_name: notification_id } = notification;
+      const {
+        notification_name: notification_id,
+        notification_created: created
+      } = notification;
 
       // strips away the host from url
       const relative_link = link.replace(/^.*\/\/[^\/]+/, '');

--- a/src/public-modules/Notification/helpers.js
+++ b/src/public-modules/Notification/helpers.js
@@ -1,9 +1,8 @@
 export const deserializeNotification = notificationItem => {
   const {
-    notification: { from_user, notification_name },
+    notification: { from_user, notification_name, notification_created },
     data: { link, bounty_title },
     viewed,
-    created,
     id
   } = notificationItem;
   return {
@@ -12,7 +11,7 @@ export const deserializeNotification = notificationItem => {
     // make link relative
     link: link.replace(/^.*\/\/[^\/]+/, ''),
     bounty_title,
-    created,
+    created: notification_created,
     viewed,
     id
   };


### PR DESCRIPTION
ref: https://github.com/Bounties-Network/BountiesAPI/pull/119

Will merge these together once we are ready for a resync.
This is compatible with the new updates on the notification client that saves the true event date. This lets us give the correct date on notifications after a sync.