### PR TITLE
Fix slow loading times

### DIFF
--- a/src/containers/ActivityPanel/index.js
+++ b/src/containers/ActivityPanel/index.js
@@ -135,8 +135,7 @@ const ActivityPanel = compose(
       load: actions.loadActivity,
       loadMore: actions.loadMoreActivity
     }
-  ),
-  LoadComponent('public_address')
+  )
 )(ActivityPanelComponent);
 
 export default ActivityPanel;

--- a/src/containers/BountiesPanel/index.js
+++ b/src/containers/BountiesPanel/index.js
@@ -174,8 +174,7 @@ const BountiesPanel = compose(
       activeLoadMore: bountiesActions.loadMoreBounties,
       draftsLoadMore: draftsActions.loadMoreDrafts
     }
-  ),
-  LoadComponent('')
+  )
 )(BountiesPanelComponent);
 
 export default BountiesPanel;

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
 import styles from './Dashboard.module.scss';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -10,7 +12,19 @@ import {
   UserStats
 } from 'containers';
 
-class Dashboard extends React.Component {
+import { getCurrentUserSelector } from 'public-modules/Authentication/selectors';
+import { actions as activityActions } from 'public-modules/Activity';
+import { actions as bountiesPanelActions } from 'containers/BountiesPanel/reducer';
+import { actions as submissionsPanelActions } from 'containers/SubmissionsPanel/reducer';
+
+class DashboardComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    props.loadActivityPanel(props.public_address);
+    props.loadBountiesPanel();
+    props.loadSubmissionsPanel();
+  }
+
   render() {
     var settings = {
       dots: true,
@@ -65,5 +79,25 @@ class Dashboard extends React.Component {
     );
   }
 }
+
+const mapStateToProps = state => {
+  const currentUser = getCurrentUserSelector(state);
+  const { public_address } = currentUser;
+
+  return {
+    public_address
+  };
+};
+
+const Dashboard = compose(
+  connect(
+    mapStateToProps,
+    {
+      loadSubmissionsPanel: submissionsPanelActions.loadSubmissionsPanel,
+      loadBountiesPanel: bountiesPanelActions.loadBountiesPanel,
+      loadActivityPanel: activityActions.loadActivity
+    }
+  )
+)(DashboardComponent);
 
 export default Dashboard;

--- a/src/containers/SubmissionsPanel/index.js
+++ b/src/containers/SubmissionsPanel/index.js
@@ -177,8 +177,7 @@ const SubmissionsPanel = compose(
       loadMore: fulfillmentActions.loadMoreFulfillments,
       setActiveTab: actions.setActiveTab
     }
-  ),
-  LoadComponent('')
+  )
 )(SubmissionsPanelComponent);
 
 export default SubmissionsPanel;


### PR DESCRIPTION
@villanuevawill @codeluggage this should fix the issues we were having with really slow load times. They were being caused by tons of extraneous requests to the API which were caused mainly by the mobile containers being hidden only by CSS. This means that they were mounted in parallel with the desktop containers and there sagas were running in tandem. It still isn't perfect, but I wanted to push this up as an immediate fix and then talk about better patterns for the sagas because I'm not happy with the "pattern" I have laid out thus far.