### PR TITLE
Fix issue where fulfillment modal was not submitting

### DIFF
--- a/src/containers/Bounty/components/modals/FulfillBountyFormModal.js
+++ b/src/containers/Bounty/components/modals/FulfillBountyFormModal.js
@@ -123,7 +123,7 @@ let FulfillBountyFormModalComponent = props => {
           >
             Cancel
           </Button>
-          <Button disabled={uploading} type="primary" buttonType="button">
+          <Button disabled={uploading} type="primary" buttonType="submit">
             Submit
           </Button>
         </Modal.Footer>


### PR DESCRIPTION
@villanuevawill @codeluggage there is a strange issue such that the fulfillments form was not getting submitted due to the `buttonType === button`. I'm still not sure how this happened, if either of you have any ideas on what might be the underlining cause I would love to find out.