### PR TITLE
Load fulfillment info even if query string isn't there

### DIFF
--- a/src/containers/Bounty/index.js
+++ b/src/containers/Bounty/index.js
@@ -78,6 +78,7 @@ class BountyComponent extends React.Component {
           break;
         }
         default: {
+          loadFulfillments();
           setActiveTab('comments');
         }
       }


### PR DESCRIPTION
@villanuevawill @codeluggage quick fix