### PR TITLE
Copy change to make comment notification user agnostic

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -140,7 +140,7 @@ export const notification_template = {
     icon: arrow_up
   },
   [NOTIFICATION_ID.BOUNTY_COMMENT_RECEIVED]: {
-    message: 'You received a comment',
+    message: 'Someone commented on',
     icon: comment
   },
   [NOTIFICATION_ID.BOUNTY_ISSUED_ACTIVATED]: {


### PR DESCRIPTION
Now that more users than just the issuer receive a notification when a comment has been posted on a bounty they're involved with, we want that to reflect in the copy. 