### PR TITLE
set white-space to prewrap on submission descriptions

### DIFF
--- a/src/containers/Bounty/components/listItems/SubmissionItem.module.scss
+++ b/src/containers/Bounty/components/listItems/SubmissionItem.module.scss
@@ -69,6 +69,7 @@
 
 .submissionDescription {
   line-height: $base-line-height;
+  white-space: pre-wrap;
 }
 
 .fileIcon {


### PR DESCRIPTION
@villanuevawill @codeluggage fixed an issue with newlines not rendering in submission descriptions