### PR TITLE
fix incorrect currency color on bounty page

### DIFF
--- a/src/containers/Bounty/index.js
+++ b/src/containers/Bounty/index.js
@@ -191,6 +191,7 @@ class BountyComponent extends React.Component {
                 primaryColor="white"
                 primaryClassName={styles.primary}
                 primaryContainerClass={styles.primaryContainerClass}
+                currencyColor="white"
                 secondaryValue={bounty.calculated_fulfillmentAmount}
                 secondaryCurrency={bounty.tokenSymbol}
                 secondaryTypeScale="h4"


### PR DESCRIPTION
@villanuevawill @codeluggage @corwinharrell while merging and rebase this somehow got lost, but I added back in the specific color for tokens on the bounty page when it is a token specific explorer.  