### PR TITLE
add logic to hide dropdown if there is only one platform

### DIFF
--- a/src/containers/Leaderboard/LeaderboardCard.js
+++ b/src/containers/Leaderboard/LeaderboardCard.js
@@ -75,7 +75,7 @@ const LeaderboardCardComponent = props => {
     )
   ];
 
-  const platformDropdown = (
+  const platformDropdown = config.platform.split(',').length > 1 && (
     <div className={styles.platformSelect}>
       <SearchSelect
         single


### PR DESCRIPTION
@villanuevawill here is that hotfix to hide the dropdown on the berlin explorer