### PR TITLE
Android link to status for wallet, other wallet link fixes

### DIFF
--- a/src/containers/Login/components/WalletRequired.js
+++ b/src/containers/Login/components/WalletRequired.js
@@ -17,9 +17,9 @@ const WalletRequired = props => {
   }
 
   if (operatingSystem === 'Android') {
-    walletName = 'Coinbase Wallet';
+    walletName = 'Status Wallet';
     walletLink =
-      'https://play.google.com/store/apps/details?id=com.coinbase.android';
+      'https://play.google.com/store/apps/details?id=im.status.ethereum';
   }
 
   return (
@@ -59,8 +59,8 @@ const WalletRequired = props => {
             Cancel
           </Button>
         )}
-        <a href="https://metamask.io/">
-          <Button type="primary">Visit MetaMask.io</Button>
+        <a href={walletLink}>
+          <Button type="primary">Visit {walletName}</Button>
         </a>
       </Modal.Footer>
     </Modal>


### PR DESCRIPTION
1. Link to status for android phones
2. Button should not say visit metamask on mobile when we link to coinbase wallet or status