### PR TITLE
Mobile nav closes on tos/privacy check

### DIFF
--- a/src/layout/App/index.js
+++ b/src/layout/App/index.js
@@ -64,6 +64,7 @@ class HeaderComponent extends React.Component {
 
     if (prevProps.location.pathname !== pathname) {
       document.getElementsByClassName('page-body')[0].scrollTo(0, 0);
+      this.setState({ showMobileSidebar: false });
     }
   }
 

--- a/src/utils/global.js
+++ b/src/utils/global.js
@@ -1,6 +1,6 @@
-export let web3 = {};
-
 import config from 'public-modules/config';
+
+export let web3 = {};
 
 let API_ENDPOINT = config.url.mainNet;
 //let API_ENDPOINT = 'http://localhost:8000';

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,13 +1,14 @@
 import axios from 'axios';
 
 import {
-  apiEndpoint,
   HTTP_401_UNAUTHORIZED,
   HTTP_200_OK,
   HTTP_403_FORBIDDEN,
   HTTP_500_INTERNAL_SERVER_ERROR,
   HTTP_300_MULTIPLE_CHOICES
 } from './constants';
+
+import { apiEndpoint } from './global';
 
 import rollbar from 'lib/rollbar';
 


### PR DESCRIPTION
- Fixes bug where the mobile nave does not close on selecting the privacy or TOS link.
- Fixes issues introduced from the storybook deploy