### PR TITLE
Always show the most interesting review tab

### DIFF
--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -18,6 +18,7 @@ import { rootBountiesSelector } from 'public-modules/Bounties/selectors';
 import { locationNonceSelector } from 'layout/App/selectors';
 import { SEOHeader } from './components';
 import { actions } from './reducer';
+import { queryStringToObject } from 'utils/locationHelpers';
 
 class ProfileComponent extends React.Component {
   constructor(props) {
@@ -32,11 +33,13 @@ class ProfileComponent extends React.Component {
       currentUser,
       history,
       match,
+      location,
       loadUserInfo,
       setActiveTab,
       setProfileAddress,
       resetState,
-      initFilterNav
+      initFilterNav,
+      setReviewsModalVisible
     } = this.props;
 
     initFilterNav(filterConfig);
@@ -58,6 +61,12 @@ class ProfileComponent extends React.Component {
     loadUserInfo(address.toLowerCase());
     setProfileAddress(address.toLowerCase());
     setActiveTab('issued');
+
+    const values = queryStringToObject(location.search);
+
+    if (values.reviews) {
+      setReviewsModalVisible(true);
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -232,7 +241,8 @@ const Profile = compose(
       resetFilter: bountiesActions.resetFilter,
       loadUserInfo: userInfoActions.loadUserInfo,
       setActiveTab: actions.setActiveTab,
-      setProfileAddress: actions.setProfileAddress
+      setProfileAddress: actions.setProfileAddress,
+      setReviewsModalVisible: actions.setReviewsModalVisible
     }
   )
 )(ProfileComponent);

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -33,13 +33,11 @@ class ProfileComponent extends React.Component {
       currentUser,
       history,
       match,
-      location,
       loadUserInfo,
       setActiveTab,
       setProfileAddress,
       resetState,
-      initFilterNav,
-      setReviewsModalVisible
+      initFilterNav
     } = this.props;
 
     initFilterNav(filterConfig);
@@ -61,12 +59,6 @@ class ProfileComponent extends React.Component {
     loadUserInfo(address.toLowerCase());
     setProfileAddress(address.toLowerCase());
     setActiveTab('issued');
-
-    const values = queryStringToObject(location.search);
-
-    if (values.reviews) {
-      setReviewsModalVisible(true);
-    }
   }
 
   componentDidUpdate(prevProps) {
@@ -123,6 +115,21 @@ class ProfileComponent extends React.Component {
   componentDidMount() {
     const body = document.getElementsByClassName('page-body')[0];
     body.addEventListener('scroll', this.onScroll);
+
+    const {
+      location,
+      setReviewsModalVisible,
+      setActiveNetworkSwitch
+    } = this.props;
+    const { reviews, fulfiller } = queryStringToObject(location.search);
+
+    if (fulfiller) {
+      setActiveNetworkSwitch('fulfiller');
+    }
+
+    if (reviews) {
+      setReviewsModalVisible(true);
+    }
   }
 
   componentWillUnmount() {
@@ -242,7 +249,8 @@ const Profile = compose(
       loadUserInfo: userInfoActions.loadUserInfo,
       setActiveTab: actions.setActiveTab,
       setProfileAddress: actions.setProfileAddress,
-      setReviewsModalVisible: actions.setReviewsModalVisible
+      setReviewsModalVisible: actions.setReviewsModalVisible,
+      setActiveNetworkSwitch: actions.setActiveNetworkSwitch
     }
   )
 )(ProfileComponent);

--- a/src/containers/Profile/reducer.js
+++ b/src/containers/Profile/reducer.js
@@ -7,6 +7,7 @@ const initialState = {
 
 const SET_PROFILE_ADDRESS = 'profileUI/SET_PROFILE_ADDRESS';
 const TOGGLE_NETWORK_SWITCH = 'profileUI/TOGGLE_NETWORK_SWITCH';
+const SET_ACTIVE_NETWORK_SWITCH = 'profileUI/SET_ACTIVE_NETWORK_SWITCH';
 const SET_ACTIVE_TAB = 'profileUI/SET_ACTIVE_TAB';
 const SET_REVIEWS_MODAL_VISIBLE = 'profileUI/SET_REVIEWS_MODAL_VISIBLE';
 
@@ -16,6 +17,10 @@ function setProfileAddress(address) {
 
 function toggleNetworkSwitch() {
   return { type: TOGGLE_NETWORK_SWITCH };
+}
+
+function setActiveNetworkSwitch(switchValue) {
+  return { type: SET_ACTIVE_NETWORK_SWITCH, switchValue };
 }
 
 function setActiveTab(tabKey) {
@@ -40,6 +45,14 @@ function profileUIReducer(state = initialState, action) {
       return {
         ...state,
         switchValue: state.switchValue === 'issuer' ? 'fulfiller' : 'issuer'
+      };
+    }
+    case SET_ACTIVE_NETWORK_SWITCH: {
+      const { switchValue } = action;
+
+      return {
+        ...state,
+        switchValue
       };
     }
     case SET_PROFILE_ADDRESS: {
@@ -67,6 +80,7 @@ function profileUIReducer(state = initialState, action) {
 export const actions = {
   setProfileAddress,
   toggleNetworkSwitch,
+  setActiveNetworkSwitch,
   setActiveTab,
   setReviewsModalVisible
 };
@@ -74,6 +88,7 @@ export const actions = {
 export const actionTypes = {
   SET_PROFILE_ADDRESS,
   TOGGLE_NETWORK_SWITCH,
+  SET_ACTIVE_NETWORK_SWITCH,
   SET_ACTIVE_TAB,
   SET_REVIEWS_MODAL_VISIBLE
 };

--- a/src/containers/Profile/sagas.js
+++ b/src/containers/Profile/sagas.js
@@ -4,7 +4,11 @@ import { actionTypes } from './reducer';
 import { actions as reviewsActions } from 'public-modules/Reviews';
 import { actions as bountiesActions } from 'public-modules/Bounties';
 
-const { SET_ACTIVE_TAB, TOGGLE_NETWORK_SWITCH } = actionTypes;
+const {
+  SET_ACTIVE_TAB,
+  TOGGLE_NETWORK_SWITCH,
+  SET_ACTIVE_NETWORK_SWITCH
+} = actionTypes;
 const { addIssuerFilter, addFulfillerFilter } = bountiesActions;
 const { loadBounties } = bountiesActions;
 const { loadReviewsReceived } = reviewsActions;
@@ -28,7 +32,10 @@ export function* networkSwitchChanged(action) {
 }
 
 export function* watchNetworkSwitch() {
-  yield takeLatest(TOGGLE_NETWORK_SWITCH, networkSwitchChanged);
+  yield takeLatest(
+    [TOGGLE_NETWORK_SWITCH, SET_ACTIVE_NETWORK_SWITCH],
+    networkSwitchChanged
+  );
 }
 
 export function* watchProfileTab() {


### PR DESCRIPTION
Trello: https://trello.com/c/z8oOHfn9

This branches off of https://github.com/Bounties-Network/Explorer/pull/209, which should be merged first. This branch can target master after that. For now, it targets https://github.com/Bounties-Network/Explorer/pull/209 in order to show the correct diff.

A few considerations worth discussing: 

- Only one type of reviews will be loaded at a time. I check if there are any reviews (issuer) and if there are none, I switch to the fulfiller reviews. This does not guarantee that there are fulfiller reviews, but it is efficient and simple. 
- A querystring can override this "most interesting tab", and that's why this PR is based off of https://github.com/Bounties-Network/Explorer/pull/209
- State for having set the tab already was used because reviews go back into a loading state when clicking the other tab. There might be a more elegant way to solve this. 