### PR TITLE
Add utility function to expand platforms into their subplatforms

### DIFF
--- a/src/public-modules/Bounties/selectors.js
+++ b/src/public-modules/Bounties/selectors.js
@@ -5,6 +5,7 @@ import {
   PAGE_SIZE
 } from 'public-modules/Bounties/constants';
 import config from 'public-modules/config';
+import { expandPlatforms } from 'utils/helpers';
 import { reduce as reduceFunction, every, negate } from 'lodash';
 const reduce = reduceFunction.convert({ cap: false });
 
@@ -66,9 +67,11 @@ export const bountiesQuerySelector = createSelector(
     if (rootBounty.sortOrder === 'desc') {
       orderPrefix += '-';
     }
+
     query['platform__in'] = platforms.length
-      ? platforms.join(',')
-      : config.platform;
+      ? expandPlatforms(platforms).join(',')
+      : expandPlatforms(config.platform.split(',')).join(',');
+
     query['bountyStage__in'] = reduce(
       (result, value, key) => {
         if (value) {
@@ -79,6 +82,7 @@ export const bountiesQuerySelector = createSelector(
       [],
       rootBounty.stageFilters
     ).join(',');
+
     query['experienceLevel__in'] = reduce(
       (result, value, key) => {
         if (value) {

--- a/src/public-modules/production_settings.json
+++ b/src/public-modules/production_settings.json
@@ -1,5 +1,8 @@
 {
   "platform": "bounties-network,gitcoin",
+  "subPlatforms": {
+    "bounties-network": ["sf", "berlin"]
+  },
   "postingPlatform": "bounties-network",
   "postingSchema": "standardSchema",
   "postingSchemaVersion": "0.1",

--- a/src/public-modules/staging_settings.json
+++ b/src/public-modules/staging_settings.json
@@ -1,5 +1,8 @@
 {
   "platform": "bounties-network,gitcoin",
+  "subPlatforms": {
+    "bounties-network": ["sf", "berlin"]
+  },
   "postingPlatform": "bounties-network",
   "postingSchema": "standardSchema",
   "postingSchemaVersion": "0.1",

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,6 @@
+import config from 'public-modules/config';
+import { flatten, map } from 'lodash';
+
 export function getTimezone() {
   if (Intl && Intl.DateTimeFormat) {
     const dateTimeFormat = Intl.DateTimeFormat();
@@ -110,3 +113,14 @@ export function promisifyDebounce(inner, ms = 0) {
     return new Promise(r => resolves.push(r));
   };
 }
+
+export const expandPlatforms = platforms => {
+  if (!config.subPlatforms) return platforms;
+
+  return flatten(
+    map(platform => {
+      const subPlatforms = config.subPlatforms[platform];
+      return subPlatforms ? [platform, ...subPlatforms] : platform;
+    }, platforms)
+  );
+};


### PR DESCRIPTION
@villanuevawill @codeluggage this PR adds a new field in the config.json that allows us to describe "subplatforms". For example, `sf` and `berlin` could be subplatforms of `bounties-network`.