### PR TITLE
Fix rating modal profile links

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -50,7 +50,7 @@ const Avatar = props => {
         <Text
           typeScale={addressTextScale}
           color={addressTextColor}
-          src={src}
+          src={src ? src : '/profile/' + address}
           onClick={onClick}
           link
         >


### PR DESCRIPTION
Trello: https://trello.com/c/8SNCzND2

This makes the Avatar component fall back to address link if no src prop is available.