### PR TITLE
Implement absolute links in explorer

### DIFF
--- a/src/components/MarkdownEditor/index.js
+++ b/src/components/MarkdownEditor/index.js
@@ -7,7 +7,15 @@ import { DEFAULT_MARKDOWN } from 'utils/constants';
 import { Textbox, Modal, Text } from 'components';
 
 showdown.setOption('simpleLineBreaks', true);
-const converter = new showdown.Converter();
+showdown.extension('targetBlank', () => [
+  {
+    type: 'output',
+    regex: '<a(.*?)>',
+    replace: (_, content) => '<a target="_blank"' + content + '>'
+  }
+]);
+
+const converter = new showdown.Converter({ extensions: ['targetBlank'] });
 converter.setFlavor('github');
 
 class MarkdownEditor extends React.Component {

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -18,7 +18,8 @@ const Text = props => {
     id,
     onClick,
     download,
-    onMouseDown
+    onMouseDown,
+    absolute
   } = props;
 
   let addedClasses = '';
@@ -44,6 +45,9 @@ const Text = props => {
   if (link) {
     addedClasses += ` ${styles.Link}`;
 
+    const forceAbsolute = src =>
+      src.slice(0, 4) === 'http' ? src : `//${src}`;
+
     return (
       <a
         onMouseDown={onMouseDown}
@@ -53,7 +57,7 @@ const Text = props => {
           styles[fontStyle]
         } ${addedClasses}`}
         id={id}
-        href={src}
+        href={absolute ? forceAbsolute(src) : src}
         onClick={onClick}
         download={download}
       >
@@ -106,6 +110,7 @@ Text.propTypes = {
   inline: PropTypes.bool,
   src: PropTypes.string,
   link: PropTypes.bool,
+  absolute: PropTypes.bool,
   onClick: PropTypes.func,
   color: PropTypes.oneOf([
     'purple',
@@ -139,6 +144,7 @@ Text.defaultProps = {
   onMouseDown: () => {},
   src: null,
   link: false,
+  absolute: false,
   weight: 'fontWeight-regular',
   id: ''
 };

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -60,6 +60,7 @@ const Text = props => {
         href={absolute ? forceAbsolute(src) : src}
         onClick={onClick}
         download={download}
+        target={absolute ? 'target="_blank"' : ''}
       >
         {props.children}
       </a>

--- a/src/containers/Bounty/components/listItems/SubmissionItem.js
+++ b/src/containers/Bounty/components/listItems/SubmissionItem.js
@@ -132,7 +132,7 @@ const SubmissionItem = props => {
         {url ? (
           <div className={[styles.labelGroup, styles.bottomMargin].join(' ')}>
             <Text inputLabel>Web link</Text>
-            <Text link src={url}>
+            <Text link absolute src={url}>
               {shortenUrl(url)}
             </Text>
           </div>

--- a/src/containers/Bounty/index.js
+++ b/src/containers/Bounty/index.js
@@ -347,6 +347,7 @@ class BountyComponent extends React.Component {
                       </i>
                       <Text
                         link
+                        absolute
                         src={`https://ipfs.infura.io/ipfs/${
                           bounty.sourceDirectoryHash
                         }/${bounty.sourceFileName}`}
@@ -361,7 +362,7 @@ class BountyComponent extends React.Component {
                       <i className={styles.metadataIcon}>
                         <FontAwesomeIcon icon={['far', 'link']} />
                       </i>
-                      <Text link src={`${bounty.webReferenceURL}`}>
+                      <Text link absolute src={`${bounty.webReferenceURL}`}>
                         {shortenUrl(bounty.webReferenceURL)}
                       </Text>
                     </div>

--- a/src/containers/Profile/components/Elsewhere/index.js
+++ b/src/containers/Profile/components/Elsewhere/index.js
@@ -60,7 +60,7 @@ const Elsewhere = props => {
               icon={['fab', 'linkedin']}
               className={styles.icon}
             />
-            <Text link src={linkedin} typeScale="h5">
+            <Text link absolute src={linkedin} typeScale="h5">
               LinkedIn
             </Text>
           </div>

--- a/src/containers/Profile/components/Elsewhere/index.js
+++ b/src/containers/Profile/components/Elsewhere/index.js
@@ -17,7 +17,7 @@ const Elsewhere = props => {
         {website && (
           <div className={styles.bulletPoint}>
             <FontAwesomeIcon icon={['far', 'globe']} className={styles.icon} />
-            <Text link src={website} typeScale="h5">
+            <Text link absolute src={website} typeScale="h5">
               {shortenUrl(website)}
             </Text>
           </div>
@@ -29,7 +29,12 @@ const Elsewhere = props => {
               icon={['fab', 'twitter']}
               className={styles.icon}
             />
-            <Text link src={`https://twitter.com/@${twitter}`} typeScale="h5">
+            <Text
+              link
+              absolute
+              src={`https://twitter.com/@${twitter}`}
+              typeScale="h5"
+            >
               Twitter
             </Text>
           </div>
@@ -38,7 +43,12 @@ const Elsewhere = props => {
         {github && (
           <div className={styles.bulletPoint}>
             <FontAwesomeIcon icon={['fab', 'github']} className={styles.icon} />
-            <Text link src={`https://github.com/${github}`} typeScale="h5">
+            <Text
+              link
+              absolute
+              src={`https://github.com/${github}`}
+              typeScale="h5"
+            >
               Github
             </Text>
           </div>


### PR DESCRIPTION
@villanuevawill @codeluggage this PR addresses the recent bug in the text's link functionality and this Trello card https://trello.com/c/pIdnjmTX/175-bug-any-links-on-the-bounty-page-to-outside-links-or-to-associated-files-should-always-open-in-a-new-tab-using-targetblank.