### PR TITLE
Growing textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-slick": "^0.23.1",
     "react-sticky": "^6.0.3",
     "react-switch": "^3.0.2",
+    "react-textarea-autosize": "^7.0.4",
     "react-toastify": "^4.1.0",
     "react-toggle": "^4.0.2",
     "react-transition-group": "^2.4.0",

--- a/src/components/Textbox/index.js
+++ b/src/components/Textbox/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Textarea from 'react-textarea-autosize';
 import styles from './Textbox.module.scss';
 
 import { Text } from 'components';
@@ -56,15 +57,15 @@ class Textbox extends React.Component {
 
     return (
       <div className={`${styles.wrapper} ${className}`}>
-        {labelText ? (
+        {labelText && (
           <div>
             <Text inputLabel color={error ? 'red' : null}>
               {labelText}
             </Text>
           </div>
-        ) : null}
+        )}
         <div className={styles.textareaWrapper}>
-          <textarea
+          <Textarea
             className={`${inputClass} ${textAreaClass}`}
             placeholder={placeholder}
             disabled={disabled}
@@ -75,7 +76,7 @@ class Textbox extends React.Component {
           />
           {overlay ? <div className={styles.overlay}>{overlay}</div> : null}
         </div>
-        {error ? (
+        {error && (
           <div>
             <Text
               className={styles.inputHelpText}
@@ -85,7 +86,7 @@ class Textbox extends React.Component {
               {error}
             </Text>
           </div>
-        ) : null}
+        )}
       </div>
     );
   }

--- a/src/components/Textbox/index.js
+++ b/src/components/Textbox/index.js
@@ -30,8 +30,7 @@ class Textbox extends React.Component {
       overlay,
       value,
       onFocus,
-      onBlur,
-      rows
+      onBlur
     } = this.props;
 
     const { text: textStateValue } = this.state;
@@ -73,7 +72,6 @@ class Textbox extends React.Component {
             onBlur={onBlur}
             value={textValue}
             onChange={this.onTextareaChange}
-            rows={rows}
           />
           {overlay ? <div className={styles.overlay}>{overlay}</div> : null}
         </div>

--- a/src/containers/Bounty/components/NewCommentForm.js
+++ b/src/containers/Bounty/components/NewCommentForm.js
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { formValueSelector } from 'redux-form';
 import { Field, reduxForm } from 'redux-form';
-import { FormTextbox } from 'form-components';
+import { FormTextInput } from 'form-components';
 
 const formSelector = formValueSelector('newComment');
 
@@ -18,11 +18,9 @@ const NewCommentForm = props => {
         <div className={`${styles.container} ${className}`}>
           <Field
             name="text"
-            component={FormTextbox}
+            component={FormTextInput}
             type="text"
             placeholder="Write a comment..."
-            rows={3}
-            textAreaClass={styles.rowTextArea}
           />
           <Button disabled={loading || text.length === 0} loading={loading}>
             Post comment

--- a/src/containers/Bounty/components/NewCommentForm.js
+++ b/src/containers/Bounty/components/NewCommentForm.js
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { formValueSelector } from 'redux-form';
 import { Field, reduxForm } from 'redux-form';
-import { FormTextInput } from 'form-components';
+import { FormTextbox } from 'form-components';
 
 const formSelector = formValueSelector('newComment');
 
@@ -18,9 +18,10 @@ const NewCommentForm = props => {
         <div className={`${styles.container} ${className}`}>
           <Field
             name="text"
-            component={FormTextInput}
+            component={FormTextbox}
             type="text"
             placeholder="Write a comment..."
+            textAreaClass={styles.growingTextArea}
           />
           <Button disabled={loading || text.length === 0} loading={loading}>
             Post comment

--- a/src/containers/Bounty/components/NewCommentForm.module.scss
+++ b/src/containers/Bounty/components/NewCommentForm.module.scss
@@ -13,5 +13,6 @@
 
 .growingTextArea {
   min-height: $base-input-height;
+  max-height: $base-input-height * 5;
   resize: none;
 }

--- a/src/containers/Bounty/components/NewCommentForm.module.scss
+++ b/src/containers/Bounty/components/NewCommentForm.module.scss
@@ -10,3 +10,8 @@
     padding-right: $base-spacing;
   }
 }
+
+.growingTextArea {
+  min-height: $base-input-height;
+  resize: none;
+}

--- a/src/containers/Bounty/components/NewCommentForm.module.scss
+++ b/src/containers/Bounty/components/NewCommentForm.module.scss
@@ -10,8 +10,3 @@
     padding-right: $base-spacing;
   }
 }
-
-.rowTextArea {
-	min-height: 10px;
-	resize: none;
-}

--- a/src/containers/Bounty/components/listItems/CommentItem.module.scss
+++ b/src/containers/Bounty/components/listItems/CommentItem.module.scss
@@ -5,6 +5,7 @@
   line-height: $base-line-height;
   padding-left: $xl-spacing + $m-spacing;
   padding-top: $l-spacing;
+  white-space: pre-wrap;
 
   @media only screen and (min-width: 48em) {
     padding-left: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8107,6 +8107,12 @@ react-switch@^3.0.2:
   dependencies:
     prop-types "^15.6.1"
 
+react-textarea-autosize@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.0.4.tgz#4e4be649b544a88713e7b5043f76950f35d3d503"
+  dependencies:
+    prop-types "^15.6.0"
+
 react-toastify@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-4.1.0.tgz#0d14d3cf36523ade27a2edd5323a9db373dce4c5"


### PR DESCRIPTION
This follows up on https://github.com/Bounties-Network/Explorer/pull/239
Trello: https://trello.com/c/GdwgjN6X
Up on staging: https://staging.bounties.network (though I only saw it properly take effect in a new private Firefox window, not after hard refreshing a regular window)

- Adds the https://github.com/andreypopp/react-textarea-autosize textarea
- Styles it to fit our `$base-input-height` and not be resizeable, for our comment input