### PR TITLE
Network stats switch loading fix

### DIFF
--- a/src/containers/Profile/ProfileDetails.js
+++ b/src/containers/Profile/ProfileDetails.js
@@ -21,87 +21,144 @@ import {
 import { profileUISelector } from './selectors';
 import { actions } from './reducer';
 
-const ProfileDetailsComponent = props => {
-  const {
-    loading,
-    user,
-    userStats,
-    loadedUserInfo,
-    switchValue,
-    toggleNetworkSwitch,
-    currentTab,
-    setActiveTab,
-    setReviewsModalVisible
-  } = props;
+class ProfileDetailsComponent extends React.Component {
+  constructor(props) {
+    super(props);
 
-  let bodyClass;
-
-  let body = (
-    <React.Fragment>
-      <ProfileAvatar
-        name={user.name}
-        address={user.public_address}
-        img={user.large_profile_image_url}
-        className={styles.profileAvatar}
-      />
-      <div className={styles.details}>
-        <div className={`${styles.detailsSection} ${styles.detailsStats}`}>
-          <NetworkStats
-            stats={userStats}
-            switchValue={switchValue}
-            toggleNetworkSwitch={toggleNetworkSwitch}
-            address={user.public_address}
-            setReviewsModalVisible={setReviewsModalVisible}
-          />
-        </div>
-        {!!user.skills &&
-          !!user.skills.length && (
-            <div className={`${styles.detailsSection} ${styles.detailsSkills}`}>
-              <Skills skills={user.skills} />
-            </div>
-          )}
-        {(!!user.organization ||
-          (user.languages && !!user.languages.length)) && (
-          <div className={`${styles.detailsSection} ${styles.detailsAbout}`}>
-            <About
-              organization={user.organization}
-              languages={user.languages}
-            />
-          </div>
-        )}
-        {(user.website || user.twitter || user.github || user.linkedin) && (
-          <div
-            className={`${styles.detailsSection} ${styles.detailsElsewhere}`}
-          >
-            <Elsewhere
-              website={user.website}
-              twitter={user.twitter}
-              github={user.github}
-              linkedin={user.linkedin}
-            />
-          </div>
-        )}
-      </div>
-      <div className="row">
-        <div className="col-xs-12">
-          <ProfileTabs
-            currentTab={currentTab}
-            setActiveTab={setActiveTab}
-            issuedCount={loadedUserInfo.stats.total_bounties || 0}
-            fulfilledCount={loadedUserInfo.stats.total_fulfillments || 0}
-          />
-        </div>
-      </div>
-    </React.Fragment>
-  );
-
-  if (loading) {
-    bodyClass = styles.bodyLoading;
-    body = <Loader color="blue" size="medium" />;
+    // Don't use state, this is a set-and-forget, once-only check.
+    // We don't want to involve the lifecycle of the component at all,
+    // only as a "first load" concept to avoid a visual toggle of the switch.
+    this.networkSwitchAlreadySet = undefined;
   }
 
-  return <div className={`col-xs-12 fullHeight ${bodyClass}`}>{body}</div>;
-};
+  mostInterestingTab() {
+    const { userStats, switchValue, switchValueOverride } = this.props;
+
+    if (switchValueOverride) {
+      return switchValueOverride;
+    } else {
+      if (
+        userStats.fulfiller.total === 0 &&
+        userStats.issuer.total === 0 &&
+        userStats.fulfiller.acceptance
+      ) {
+        return 'fulfiller';
+      } else if (userStats.fulfiller.total > userStats.issuer.total) {
+        return 'fulfiller';
+      }
+    }
+
+    return switchValue;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!this.networkSwitchAlreadySet) {
+      const {
+        switchValue,
+        switchValueOverride,
+        toggleNetworkSwitch
+      } = this.props;
+
+      const mostInterestingTab = this.mostInterestingTab();
+      if (mostInterestingTab !== switchValue) {
+        this.networkSwitchAlreadySet = mostInterestingTab;
+        toggleNetworkSwitch();
+      } else if (switchValueOverride) {
+        this.networkSwitchAlreadySet = mostInterestingTab;
+      }
+    }
+  }
+
+  render() {
+    const {
+      loading,
+      user,
+      userStats,
+      loadedUserInfo,
+      switchValue,
+      switchValueOverride,
+      toggleNetworkSwitch,
+      currentTab,
+      setActiveTab,
+      setReviewsModalVisible
+    } = this.props;
+
+    let newSwitchValue = switchValue;
+    if (!this.networkSwitchAlreadySet) {
+      newSwitchValue = this.mostInterestingTab();
+    }
+
+    let bodyClass;
+
+    let body = (
+      <React.Fragment>
+        <ProfileAvatar
+          name={user.name}
+          address={user.public_address}
+          img={user.large_profile_image_url}
+          className={styles.profileAvatar}
+        />
+        <div className={styles.details}>
+          <div className={`${styles.detailsSection} ${styles.detailsStats}`}>
+            <NetworkStats
+              stats={userStats}
+              switchValue={newSwitchValue}
+              toggleNetworkSwitch={toggleNetworkSwitch}
+              address={user.public_address}
+              setReviewsModalVisible={setReviewsModalVisible}
+            />
+          </div>
+          {!!user.skills &&
+            !!user.skills.length && (
+              <div
+                className={`${styles.detailsSection} ${styles.detailsSkills}`}
+              >
+                <Skills skills={user.skills} />
+              </div>
+            )}
+          {(!!user.organization ||
+            (user.languages && !!user.languages.length)) && (
+            <div className={`${styles.detailsSection} ${styles.detailsAbout}`}>
+              <About
+                organization={user.organization}
+                languages={user.languages}
+              />
+            </div>
+          )}
+          {(user.website || user.twitter || user.github || user.linkedin) && (
+            <div
+              className={`${styles.detailsSection} ${styles.detailsElsewhere}`}
+            >
+              <Elsewhere
+                website={user.website}
+                twitter={user.twitter}
+                github={user.github}
+                linkedin={user.linkedin}
+              />
+            </div>
+          )}
+        </div>
+        <div className="row">
+          <div className="col-xs-12">
+            <ProfileTabs
+              currentTab={currentTab}
+              setActiveTab={setActiveTab}
+              issuedCount={loadedUserInfo.stats.total_bounties || 0}
+              fulfilledCount={loadedUserInfo.stats.total_fulfillments || 0}
+            />
+          </div>
+        </div>
+      </React.Fragment>
+    );
+
+    if (loading) {
+      bodyClass = styles.bodyLoading;
+      body = <Loader color="blue" size="medium" />;
+    }
+
+    return <div className={`col-xs-12 fullHeight ${bodyClass}`}>{body}</div>;
+  }
+}
 
 const mapStateToProps = state => {
   const userInfo = userInfoSelector(state);

--- a/src/containers/Profile/ProfileDetails.js
+++ b/src/containers/Profile/ProfileDetails.js
@@ -31,7 +31,7 @@ class ProfileDetailsComponent extends React.Component {
     this.networkSwitchAlreadySet = undefined;
   }
 
-  mostInterestingTab() {
+  mostInterestingStats() {
     const { userStats, switchValue, switchValueOverride } = this.props;
 
     if (switchValueOverride) {
@@ -59,12 +59,12 @@ class ProfileDetailsComponent extends React.Component {
         toggleNetworkSwitch
       } = this.props;
 
-      const mostInterestingTab = this.mostInterestingTab();
-      if (mostInterestingTab !== switchValue) {
-        this.networkSwitchAlreadySet = mostInterestingTab;
+      const mostInterestingStats = this.mostInterestingStats();
+      if (mostInterestingStats !== switchValue) {
+        this.networkSwitchAlreadySet = mostInterestingStats;
         toggleNetworkSwitch();
       } else if (switchValueOverride) {
-        this.networkSwitchAlreadySet = mostInterestingTab;
+        this.networkSwitchAlreadySet = mostInterestingStats;
       }
     }
   }
@@ -84,7 +84,7 @@ class ProfileDetailsComponent extends React.Component {
 
     let newSwitchValue = switchValue;
     if (!this.networkSwitchAlreadySet) {
-      newSwitchValue = this.mostInterestingTab();
+      newSwitchValue = this.mostInterestingStats();
     }
 
     let bodyClass;

--- a/src/containers/Profile/ProfileDetails.js
+++ b/src/containers/Profile/ProfileDetails.js
@@ -76,7 +76,6 @@ class ProfileDetailsComponent extends React.Component {
       userStats,
       loadedUserInfo,
       switchValue,
-      switchValueOverride,
       toggleNetworkSwitch,
       currentTab,
       setActiveTab,

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -79,11 +79,9 @@ class ProfileComponent extends React.Component {
       resetState,
       resetFilter,
       bountiesLoading,
-      setActiveNetworkSwitch,
-      setReviewsModalVisible,
-      userStats
+      setReviewsModalVisible
     } = this.props;
-    const { position, networkSwitchSet } = this.state;
+    const { position } = this.state;
 
     if (
       prevProps.locationNonce !== locationNonce &&
@@ -116,49 +114,24 @@ class ProfileComponent extends React.Component {
     ) {
       ReactDOM.findDOMNode(this.explorerBody).scrollIntoView(false);
     }
-
-    console.log(userStats);
-    if (!networkSwitchSet) {
-      this.setState({
-        networkSwitchSet: true
-      });
-
-      const { reviews, fulfiller, issuer } = queryStringToObject(
-        location.search
-      );
-
-      // We start on the issuer tab, so only check for reasons to switch:
-      if (!issuer && fulfiller) {
-        setActiveNetworkSwitch('fulfiller');
-      } else {
-        if (userStats.fulfiller.total === 0 && userStats.issuer.total === 0) {
-          if (userStats.fulfiller.acceptance > userStats.issuer.acceptance) {
-            setActiveNetworkSwitch('fulfiller');
-          }
-        } else if (userStats.fulfiller.total > userStats.issuer.total) {
-          setActiveNetworkSwitch('fulfiller');
-        }
-      }
-
-      if (reviews) {
-        setReviewsModalVisible(true);
-      }
-    }
   }
 
   componentDidMount() {
     const body = document.getElementsByClassName('page-body')[0];
     body.addEventListener('scroll', this.onScroll);
 
-    const {
-      location,
-      setReviewsModalVisible,
-      setActiveNetworkSwitch
-    } = this.props;
-    const { reviews, fulfiller } = queryStringToObject(location.search);
+    const { location, setReviewsModalVisible } = this.props;
 
-    if (fulfiller) {
-      setActiveNetworkSwitch('fulfiller');
+    const { reviews, fulfiller, issuer } = queryStringToObject(location.search);
+
+    if (fulfiller && !issuer) {
+      this.setState({
+        switchValueOverride: 'fulfiller'
+      });
+    } else if (issuer) {
+      this.setState({
+        switchValueOverride: 'issuer'
+      });
     }
 
     if (reviews) {
@@ -191,7 +164,7 @@ class ProfileComponent extends React.Component {
 
   render() {
     const { error, loaded, user, showFilterNav } = this.props;
-    const { position } = this.state;
+    const { position, switchValueOverride } = this.state;
 
     const profileFilterNav = (
       <BountyFilterNav
@@ -206,7 +179,7 @@ class ProfileComponent extends React.Component {
       <div className={styles.profileContainer}>
         <SEOHeader user={user} />
         <div className={`${styles.profileDetails}`}>
-          <ProfileDetails />
+          <ProfileDetails switchValueOverride={switchValueOverride} />
         </div>
         <div className={styles.profileBountiesContainer}>
           <div className={styles.profileBounties}>
@@ -259,7 +232,6 @@ const mapStateToProps = state => {
   const currentUser = getCurrentUserSelector(state);
   const userInfo = userInfoSelector(state);
   const bountyState = rootBountiesSelector(state);
-  const userStats = loadedUserStatsSelector(state);
 
   return {
     currentUser,
@@ -267,8 +239,7 @@ const mapStateToProps = state => {
     bountiesLoading: bountyState.loading,
     loaded: userInfo.loaded,
     error: userInfo.error,
-    locationNonce: locationNonceSelector(state),
-    userStats
+    locationNonce: locationNonceSelector(state)
   };
 };
 
@@ -285,8 +256,7 @@ const Profile = compose(
       loadUserInfo: userInfoActions.loadUserInfo,
       setActiveTab: actions.setActiveTab,
       setProfileAddress: actions.setProfileAddress,
-      setReviewsModalVisible: actions.setReviewsModalVisible,
-      setActiveNetworkSwitch: actions.setActiveNetworkSwitch
+      setReviewsModalVisible: actions.setReviewsModalVisible
     }
   )
 )(ProfileComponent);

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -12,10 +12,7 @@ import styles from './Profile.module.scss';
 import { ZeroState } from 'components';
 import { actions as bountiesActions } from 'public-modules/Bounties';
 import { actions as userInfoActions } from 'public-modules/UserInfo';
-import {
-  userInfoSelector,
-  loadedUserStatsSelector
-} from 'public-modules/UserInfo/selectors';
+import { userInfoSelector } from 'public-modules/UserInfo/selectors';
 import { getCurrentUserSelector } from 'public-modules/Authentication/selectors';
 import { rootBountiesSelector } from 'public-modules/Bounties/selectors';
 import { locationNonceSelector } from 'layout/App/selectors';
@@ -78,8 +75,7 @@ class ProfileComponent extends React.Component {
       setProfileAddress,
       resetState,
       resetFilter,
-      bountiesLoading,
-      setReviewsModalVisible
+      bountiesLoading
     } = this.props;
     const { position } = this.state;
 

--- a/src/containers/Profile/reducer.js
+++ b/src/containers/Profile/reducer.js
@@ -7,7 +7,6 @@ const initialState = {
 
 const SET_PROFILE_ADDRESS = 'profileUI/SET_PROFILE_ADDRESS';
 const TOGGLE_NETWORK_SWITCH = 'profileUI/TOGGLE_NETWORK_SWITCH';
-const SET_ACTIVE_NETWORK_SWITCH = 'profileUI/SET_ACTIVE_NETWORK_SWITCH';
 const SET_ACTIVE_TAB = 'profileUI/SET_ACTIVE_TAB';
 const SET_REVIEWS_MODAL_VISIBLE = 'profileUI/SET_REVIEWS_MODAL_VISIBLE';
 
@@ -17,10 +16,6 @@ function setProfileAddress(address) {
 
 function toggleNetworkSwitch() {
   return { type: TOGGLE_NETWORK_SWITCH };
-}
-
-function setActiveNetworkSwitch(switchValue) {
-  return { type: SET_ACTIVE_NETWORK_SWITCH, switchValue };
 }
 
 function setActiveTab(tabKey) {
@@ -45,14 +40,6 @@ function profileUIReducer(state = initialState, action) {
       return {
         ...state,
         switchValue: state.switchValue === 'issuer' ? 'fulfiller' : 'issuer'
-      };
-    }
-    case SET_ACTIVE_NETWORK_SWITCH: {
-      const { switchValue } = action;
-
-      return {
-        ...state,
-        switchValue
       };
     }
     case SET_PROFILE_ADDRESS: {
@@ -80,7 +67,6 @@ function profileUIReducer(state = initialState, action) {
 export const actions = {
   setProfileAddress,
   toggleNetworkSwitch,
-  setActiveNetworkSwitch,
   setActiveTab,
   setReviewsModalVisible
 };
@@ -88,7 +74,6 @@ export const actions = {
 export const actionTypes = {
   SET_PROFILE_ADDRESS,
   TOGGLE_NETWORK_SWITCH,
-  SET_ACTIVE_NETWORK_SWITCH,
   SET_ACTIVE_TAB,
   SET_REVIEWS_MODAL_VISIBLE
 };

--- a/src/containers/Profile/sagas.js
+++ b/src/containers/Profile/sagas.js
@@ -4,11 +4,7 @@ import { actionTypes } from './reducer';
 import { actions as reviewsActions } from 'public-modules/Reviews';
 import { actions as bountiesActions } from 'public-modules/Bounties';
 
-const {
-  SET_ACTIVE_TAB,
-  TOGGLE_NETWORK_SWITCH,
-  SET_ACTIVE_NETWORK_SWITCH
-} = actionTypes;
+const { SET_ACTIVE_TAB, TOGGLE_NETWORK_SWITCH } = actionTypes;
 const { addIssuerFilter, addFulfillerFilter } = bountiesActions;
 const { loadBounties } = bountiesActions;
 const { loadReviewsReceived } = reviewsActions;
@@ -32,10 +28,7 @@ export function* networkSwitchChanged(action) {
 }
 
 export function* watchNetworkSwitch() {
-  yield takeLatest(
-    [TOGGLE_NETWORK_SWITCH, SET_ACTIVE_NETWORK_SWITCH],
-    networkSwitchChanged
-  );
+  yield takeLatest(TOGGLE_NETWORK_SWITCH, networkSwitchChanged);
 }
 
 export function* watchProfileTab() {


### PR DESCRIPTION
@c-o-l-o-r @villanuevawill 

Currently deployed to https://staging.bounties.network
Try this profile to see it in action: https://staging.bounties.network/profile/0xf4b6774fca6c692ad278959a8aec795a65c8fd9b/

Previous work on this would either have issues with the order of loading, or with visual switching of the network stats after the page had loaded. 

This was because the stats are not fully loaded by the time the page renders, and to avoid a re-render and showing the network stats switching, the logic needed to be moved inside the ProfileDetails.

This ended up being much more complex that we wanted, because the network stats switch can be set with both query string and its own logic based on the fulfiller and issuer stats.

A refactor of the concept of toggling might make this even cleaner, but this PR ensures very smooth loading and covers all corner cases. 

Changes: 

- ProfileDetails is now a component class instead of a function, and is aware of whether it has loaded for the first time or not. It avoids using state so the lifecycle of the component is not triggered, because all we want is to load a given network switch as it is first rendering.
- The Profile index.js is now simpler, and only handles the querystrings as an override for the ProfileDetails. This removes the need to set the network switch and any visual indication that it is switching.
- References to setting the network switch that weren't used have been removed. 