### PR TITLE
Make upload file button a span tag to avoid firebox bug

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -61,12 +61,10 @@ const Button = props => {
       type={buttonType}
     >
       <div className={childwrapper}>
-        {icon ? <FontAwesomeIcon icon={icon} className={styles.icon} /> : null}
+        {icon && <FontAwesomeIcon icon={icon} className={styles.icon} />}
         {props.children}
       </div>
-      {loading ? (
-        <Loader className={styles.loader} color={loaderColor} />
-      ) : null}
+      {loading && <Loader className={styles.loader} color={loaderColor} />}
     </button>
   );
 };

--- a/src/components/FileUpload/index.js
+++ b/src/components/FileUpload/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './FileUpload.module.scss';
 import buttonStyles from 'components/Button/Button.module.scss';
-import { Button, Loader, Text } from 'components';
+import { Loader, Text } from 'components';
 import { bytesToSize } from 'utils/helpers';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 

--- a/src/components/FileUpload/index.js
+++ b/src/components/FileUpload/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './FileUpload.module.scss';
-import { Text, Button } from 'components';
+import buttonStyles from 'components/Button/Button.module.scss';
+import { Button, Loader, Text } from 'components';
 import { bytesToSize } from 'utils/helpers';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
@@ -98,15 +99,25 @@ class FileUpload extends React.Component {
               : null}
           </div>
         </div>
-        <Button className={styles.button} disabled={disabled} loading={loading}>
+        <span
+          className={[
+            styles.button,
+            buttonStyles.button,
+            buttonStyles.default,
+            disabled ? buttonStyles.disabled : null
+          ].join(' ')}
+        >
+          <div className={loading && buttonStyles.childwrapper}>
+            Upload file
+          </div>
+          {loading && <Loader className={buttonStyles.loader} />}
+
           <input
-            disabled={disabledState}
-            className={styles.fileInput}
             type="file"
             onChange={this.handleChange}
+            className={styles.fileInput}
           />
-          Upload file
-        </Button>
+        </span>
       </div>
     );
   }


### PR DESCRIPTION
@villanuevawill @codeluggage this fixes the issue on the fulfillment modal in firefox where the upload file button would actually submit the form. I used a span tag just like I did for the cropper component.