### PR TITLE
Force file upload links on fulfillments to open in new tab

### DIFF
--- a/src/containers/Bounty/components/listItems/SubmissionItem.js
+++ b/src/containers/Bounty/components/listItems/SubmissionItem.js
@@ -152,6 +152,7 @@ const SubmissionItem = props => {
             />
             <Text
               link
+              absolute
               src={`https://ipfs.infura.io/ipfs/${dataHash}/${dataFileName}`}
             >
               {shortenFileName(dataFileName)}


### PR DESCRIPTION
@villanuevawill @codeluggage I realized that ipfs links on the fulfillment cards weren't opening in new tab. This PR fixes that for consistency.