### PR TITLE
Profile Strength: PageBanner and ProgressBar

### DIFF
--- a/src/components/PageBanner/PageBanner.module.scss
+++ b/src/components/PageBanner/PageBanner.module.scss
@@ -1,0 +1,50 @@
+@import "~styles/variables.scss";
+
+.pageBanner {
+  background-color: $brand-lightGrey;
+  overflow: hidden;
+  transition: height 0.2s ease-out;
+}
+
+.pageBannerWrapper,
+.pageBannerWrapper-large {
+  position: relative;
+  padding: $m-spacing 0;
+  padding-right: calc(2rem + 12px);
+  padding-left: 1rem;
+  margin: 0 auto;
+}
+
+// reusing some from Modal, maybe close button should be its own component?
+.closeIcon {
+  position: absolute;
+  top: $m-spacing;
+  right: 1rem;
+  cursor: pointer;
+  color: $brand-grey;
+  font-size: 1.2em;
+
+  &:hover {
+    color: $brand-blue;
+  }
+}
+
+@media only screen and (min-width: 48em) {
+  .pageBannerWrapper,
+  .pageBannerWrapper-large {
+    padding-right: 36px;
+    padding-left: 24px;
+  }
+
+  .pageBannerWrapper {
+    max-width: 65rem;
+  }
+
+  .pageBannerWrapper-large {
+    max-width: 70rem;
+  }
+
+  .closeIcon {
+    right: 24px;
+  }
+}

--- a/src/components/PageBanner/PageBanner.module.scss
+++ b/src/components/PageBanner/PageBanner.module.scss
@@ -1,7 +1,5 @@
 @import "~styles/variables.scss";
 
-$x-button-width: 12px;
-
 .pageBanner {
   background-color: $brand-lightGrey;
   overflow: hidden;
@@ -23,6 +21,12 @@ $x-button-width: 12px;
 .pageBannerContent {
   flex: 1;
   padding-right: $m-spacing;
+}
+
+.pageBannerClose {
+  display: flex;
+  align-items: center;
+  height: $body-font-size;
 }
 
 // reusing some from Modal, maybe close button should be its own component?

--- a/src/components/PageBanner/PageBanner.module.scss
+++ b/src/components/PageBanner/PageBanner.module.scss
@@ -20,7 +20,12 @@
 
 .pageBannerContent {
   flex: 1;
-  padding-right: $m-spacing;
+}
+
+.pageBanner-dismissable {
+  .pageBannerContent {
+    padding-right: $m-spacing;
+  }
 }
 
 .pageBannerClose {

--- a/src/components/PageBanner/PageBanner.module.scss
+++ b/src/components/PageBanner/PageBanner.module.scss
@@ -1,50 +1,38 @@
 @import "~styles/variables.scss";
 
+$x-button-width: 12px;
+
 .pageBanner {
   background-color: $brand-lightGrey;
   overflow: hidden;
   transition: height 0.2s ease-out;
 }
 
-.pageBannerWrapper,
-.pageBannerWrapper-large {
-  position: relative;
-  padding: $m-spacing 0;
-  padding-right: calc(2rem + 12px);
-  padding-left: 1rem;
-  margin: 0 auto;
+.pageBannerWrapper {
+  display: flex;
+
+  // on mobile side spacing defaults to 1rem like most components
+  padding: $m-spacing;
+
+  // on desktop, the wrapClass prop drives edge padding and max width
+  @media only screen and (min-width: 48em) {
+    padding: $m-spacing 0;
+  }
+}
+
+.pageBannerContent {
+  flex: 1;
+  padding-right: $m-spacing;
 }
 
 // reusing some from Modal, maybe close button should be its own component?
 .closeIcon {
-  position: absolute;
   top: $m-spacing;
-  right: 1rem;
   cursor: pointer;
   color: $brand-grey;
   font-size: 1.2em;
 
   &:hover {
     color: $brand-blue;
-  }
-}
-
-@media only screen and (min-width: 48em) {
-  .pageBannerWrapper,
-  .pageBannerWrapper-large {
-    padding-right: 36px;
-    padding-left: 24px;
-  }
-
-  .pageBannerWrapper {
-    max-width: 65rem;
-  }
-
-  .pageBannerWrapper-large {
-    max-width: 70rem;
-  }
-
-  .closeIcon {
-    right: 24px;
   }
 }

--- a/src/components/PageBanner/PageBanner.module.scss
+++ b/src/components/PageBanner/PageBanner.module.scss
@@ -34,7 +34,6 @@
   height: $body-font-size;
 }
 
-// reusing some from Modal, maybe close button should be its own component?
 .closeIcon {
   top: $m-spacing;
   cursor: pointer;

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -5,7 +5,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { isFunction } from 'lodash';
 
 const PageBanner = props => {
-  const { children, wrapClass } = props;
+  const { children, wrapClass, className } = props;
 
   let elemRef = React.createRef();
 
@@ -24,7 +24,7 @@ const PageBanner = props => {
   };
 
   return (
-    <div className={`${styles.pageBanner}`} ref={elemRef}>
+    <div className={`${className} ${styles.pageBanner}`} ref={elemRef}>
       <div className={`${wrapClass}`}>
         <div className={`${styles.pageBannerWrapper}`}>
           <div className={`${styles.pageBannerContent}`}>{children}</div>
@@ -40,6 +40,7 @@ const PageBanner = props => {
 };
 
 PageBanner.propTypes = {
+  className: PropTypes.string,
   dismissable: PropTypes.bool,
   onClose: PropTypes.func,
   wrapClass: PropTypes.string

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -27,16 +27,11 @@ const PageBanner = props => {
     });
   };
 
-  // const onExiting = node => {
-  //   node.style.height = '0px';
-  // }
-
   return (
     <Transition
       in={visible}
       enter={false}
       onExit={onExit}
-      // onExiting={onExiting}
       unmountOnExit={true}
       timeout={200}
     >

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -2,53 +2,65 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './PageBanner.module.scss';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import { isFunction } from 'lodash';
+import { Transition } from 'react-transition-group';
 
 const PageBanner = props => {
-  const { children, wrapClass, className, dismissable } = props;
+  const {
+    visible,
+    children,
+    wrapClass,
+    className,
+    dismissable,
+    onClose
+  } = props;
 
-  let elemRef = React.createRef();
-
-  const onClose = () => {
-    const node = elemRef.current;
+  const onExit = node => {
     const height = node.getBoundingClientRect().height;
 
     node.style.height = `${height}px`;
 
-    // allow time for height set to take effect for css transition to work properly.
+    // <Transition> component onExiting would be most appropriate for this but
+    // it does not happen in the next animation frame - meaning the css
+    // transition does not take effect and no animation of height happens.
     requestAnimationFrame(() => {
       node.style.height = '0px';
     });
-
-    if (isFunction(props.onClose)) props.onClose();
   };
 
   return (
-    <div
-      className={`${className} ${styles.pageBanner} ${
-        styles[dismissable ? 'pageBanner-dismissable' : '']
-      }`}
-      ref={elemRef}
+    <Transition
+      in={visible}
+      enter={false}
+      onExit={onExit}
+      unmountOnExit={true}
+      timeout={200}
     >
-      <div className={`${wrapClass}`}>
-        <div className={`${styles.pageBannerWrapper}`}>
-          <div className={`${styles.pageBannerContent}`}>{children}</div>
-          {dismissable && (
-            <div className={`${styles.pageBannerClose}`}>
-              <FontAwesomeIcon
-                icon={['fal', 'times']}
-                className={styles.closeIcon}
-                onClick={onClose}
-              />
-            </div>
-          )}
+      <div
+        className={`${className} ${styles.pageBanner} ${
+          styles[dismissable ? 'pageBanner-dismissable' : '']
+        }`}
+      >
+        <div className={`${wrapClass}`}>
+          <div className={`${styles.pageBannerWrapper}`}>
+            <div className={`${styles.pageBannerContent}`}>{children}</div>
+            {dismissable && (
+              <div className={`${styles.pageBannerClose}`}>
+                <FontAwesomeIcon
+                  icon={['fal', 'times']}
+                  className={styles.closeIcon}
+                  onClick={onClose}
+                />
+              </div>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </Transition>
   );
 };
 
 PageBanner.propTypes = {
+  visible: PropTypes.bool,
   className: PropTypes.string,
   dismissable: PropTypes.bool,
   onClose: PropTypes.func,
@@ -56,8 +68,10 @@ PageBanner.propTypes = {
 };
 
 PageBanner.defaultProps = {
+  visible: true,
   dismissable: true,
-  wrapClass: 'pageWrapper'
+  wrapClass: 'pageWrapper',
+  onClose: () => {}
 };
 
 export default PageBanner;

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import styles from './PageBanner.module.scss';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+
+class PageBanner extends Component {
+  static propTypes = {
+    dismissable: PropTypes.bool,
+    onClose: PropTypes.func,
+    // These sizes correspond to pageWrapper and pageWrapper-large
+    size: PropTypes.oneOf(['default', 'large'])
+  };
+
+  static defaultProps = {
+    dismissable: true,
+    size: 'default'
+  };
+
+  onClose = () => {
+    const node = ReactDOM.findDOMNode(this);
+    const height = node.getBoundingClientRect
+      ? node.getBoundingClientRect().height
+      : 0;
+
+    node.style.height = `${height}px`;
+
+    requestAnimationFrame(() => {
+      node.style.height = '0px';
+    });
+
+    if (this.props.onClose) this.props.onClose();
+  };
+
+  render() {
+    const { children, size } = this.props;
+    return (
+      <div className={`${styles.pageBanner}`}>
+        <div
+          className={
+            size === 'default'
+              ? styles.pageBannerWrapper
+              : styles['pageBannerWrapper-large']
+          }
+        >
+          {children}
+          <FontAwesomeIcon
+            icon={['fal', 'times']}
+            className={styles.closeIcon}
+            onClick={this.onClose}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default PageBanner;

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -1,23 +1,13 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styles from './PageBanner.module.scss';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
-class PageBanner extends Component {
-  static propTypes = {
-    dismissable: PropTypes.bool,
-    onClose: PropTypes.func,
-    // These sizes correspond to pageWrapper and pageWrapper-large
-    size: PropTypes.oneOf(['default', 'large'])
-  };
+const PageBanner = props => {
+  const { children, wrapClass } = props;
 
-  static defaultProps = {
-    dismissable: true,
-    size: 'default'
-  };
-
-  onClose = () => {
+  const onClose = () => {
     const node = ReactDOM.findDOMNode(this);
     const height = node.getBoundingClientRect
       ? node.getBoundingClientRect().height
@@ -29,30 +19,34 @@ class PageBanner extends Component {
       node.style.height = '0px';
     });
 
-    if (this.props.onClose) this.props.onClose();
+    if (props.onClose) props.onClose();
   };
 
-  render() {
-    const { children, size } = this.props;
-    return (
-      <div className={`${styles.pageBanner}`}>
-        <div
-          className={
-            size === 'default'
-              ? styles.pageBannerWrapper
-              : styles['pageBannerWrapper-large']
-          }
-        >
-          {children}
+  return (
+    <div className={`${styles.pageBanner}`}>
+      <div className={`${wrapClass}`}>
+        <div className={`${styles.pageBannerWrapper}`}>
+          <div className={`${styles.pageBannerContent}`}>{children}</div>
           <FontAwesomeIcon
             icon={['fal', 'times']}
             className={styles.closeIcon}
-            onClick={this.onClose}
+            onClick={onClose}
           />
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+PageBanner.propTypes = {
+  dismissable: PropTypes.bool,
+  onClose: PropTypes.func,
+  wrapClass: PropTypes.string
+};
+
+PageBanner.defaultProps = {
+  dismissable: true,
+  wrapClass: 'pageBannerWrapper'
+};
 
 export default PageBanner;

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -24,22 +24,23 @@ const PageBanner = props => {
   };
 
   return (
-    <div className={`${className} ${styles.pageBanner}`} ref={elemRef}>
+    <div
+      className={`${className} ${styles.pageBanner} ${
+        styles[dismissable ? 'pageBanner-dismissable' : '']
+      }`}
+      ref={elemRef}
+    >
       <div className={`${wrapClass}`}>
         <div className={`${styles.pageBannerWrapper}`}>
-          {dismissable ? (
-            <React.Fragment>
-              <div className={`${styles.pageBannerContent}`}>{children}</div>
-              <div className={`${styles.pageBannerClose}`}>
-                <FontAwesomeIcon
-                  icon={['fal', 'times']}
-                  className={styles.closeIcon}
-                  onClick={onClose}
-                />
-              </div>
-            </React.Fragment>
-          ) : (
-            children
+          <div className={`${styles.pageBannerContent}`}>{children}</div>
+          {dismissable && (
+            <div className={`${styles.pageBannerClose}`}>
+              <FontAwesomeIcon
+                icon={['fal', 'times']}
+                className={styles.closeIcon}
+                onClick={onClose}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -5,7 +5,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { isFunction } from 'lodash';
 
 const PageBanner = props => {
-  const { children, wrapClass, className } = props;
+  const { children, wrapClass, className, dismissable } = props;
 
   let elemRef = React.createRef();
 
@@ -27,12 +27,20 @@ const PageBanner = props => {
     <div className={`${className} ${styles.pageBanner}`} ref={elemRef}>
       <div className={`${wrapClass}`}>
         <div className={`${styles.pageBannerWrapper}`}>
-          <div className={`${styles.pageBannerContent}`}>{children}</div>
-          <FontAwesomeIcon
-            icon={['fal', 'times']}
-            className={styles.closeIcon}
-            onClick={onClose}
-          />
+          {dismissable ? (
+            <React.Fragment>
+              <div className={`${styles.pageBannerContent}`}>{children}</div>
+              <div className={`${styles.pageBannerClose}`}>
+                <FontAwesomeIcon
+                  icon={['fal', 'times']}
+                  className={styles.closeIcon}
+                  onClick={onClose}
+                />
+              </div>
+            </React.Fragment>
+          ) : (
+            children
+          )}
         </div>
       </div>
     </div>
@@ -48,7 +56,7 @@ PageBanner.propTypes = {
 
 PageBanner.defaultProps = {
   dismissable: true,
-  wrapClass: 'pageBannerWrapper'
+  wrapClass: 'pageWrapper'
 };
 
 export default PageBanner;

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -27,11 +27,16 @@ const PageBanner = props => {
     });
   };
 
+  // const onExiting = node => {
+  //   node.style.height = '0px';
+  // }
+
   return (
     <Transition
       in={visible}
       enter={false}
       onExit={onExit}
+      // onExiting={onExiting}
       unmountOnExit={true}
       timeout={200}
     >

--- a/src/components/PageBanner/index.js
+++ b/src/components/PageBanner/index.js
@@ -1,29 +1,30 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styles from './PageBanner.module.scss';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { isFunction } from 'lodash';
 
 const PageBanner = props => {
   const { children, wrapClass } = props;
 
+  let elemRef = React.createRef();
+
   const onClose = () => {
-    const node = ReactDOM.findDOMNode(this);
-    const height = node.getBoundingClientRect
-      ? node.getBoundingClientRect().height
-      : 0;
+    const node = elemRef.current;
+    const height = node.getBoundingClientRect().height;
 
     node.style.height = `${height}px`;
 
+    // allow time for height set to take effect for css transition to work properly.
     requestAnimationFrame(() => {
       node.style.height = '0px';
     });
 
-    if (props.onClose) props.onClose();
+    if (isFunction(props.onClose)) props.onClose();
   };
 
   return (
-    <div className={`${styles.pageBanner}`}>
+    <div className={`${styles.pageBanner}`} ref={elemRef}>
       <div className={`${wrapClass}`}>
         <div className={`${styles.pageBannerWrapper}`}>
           <div className={`${styles.pageBannerContent}`}>{children}</div>

--- a/src/components/ProgressBar/ProgressBar.module.scss
+++ b/src/components/ProgressBar/ProgressBar.module.scss
@@ -29,18 +29,12 @@ $progress-bar-height: $base-spacing * 0.75;
   width: 100%;
   background-color: currentColor;
   border-radius: $progress-bar-height / 2;
-  -webkit-animation: progress-bar-in 0.4s ease-out;
   animation: progress-bar-in 0.4s ease-out;
 }
 
 .percentage {
   margin-left: $base-spacing;
   color: currentColor;
-}
-
-@-webkit-keyframes progress-bar-in {
-  0%   { width: 0%; }
-  100% { width: 100%; }
 }
 
 @keyframes progress-bar-in {

--- a/src/components/ProgressBar/ProgressBar.module.scss
+++ b/src/components/ProgressBar/ProgressBar.module.scss
@@ -1,0 +1,91 @@
+@import "~styles/variables.scss";
+
+$progress-bar-height: $base-spacing * 0.75;
+
+.progressBarWrapper {
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  min-width: 100px;
+}
+
+.progressBar {
+  overflow: hidden;
+  background-color: $brand-grey;
+  height: $progress-bar-height;
+  border-radius: $progress-bar-height / 2;
+  flex: 1;
+}
+
+// non-visible element is the actual progress percentage but allows the fill element to animate on load
+// this will also animate if the percentage changed after component mount
+.progressBarFillWidth {
+  height: 100%;
+  transition: width 0.2s ease-out;
+}
+
+.progressBarFill {
+  height: 100%;
+  width: 100%;
+  background-color: currentColor;
+  border-radius: $progress-bar-height / 2;
+  -webkit-animation: progress-bar-in 0.4s ease-out;
+  animation: progress-bar-in 0.4s ease-out;
+}
+
+.percentage {
+  margin-left: $base-spacing;
+  color: currentColor;
+}
+
+@-webkit-keyframes progress-bar-in {
+  0%   { width: 0%; }
+  100% { width: 100%; }
+}
+
+@keyframes progress-bar-in {
+  0%   { width: 0%; }
+  100% { width: 100%; }
+}
+
+
+// Matches color prop for Text component. Perhaps global?
+.purple {
+  color: $brand-purple;
+}
+
+.blue {
+  color: $brand-blue;
+}
+
+.orange {
+  color: $brand-orange;
+}
+
+.green {
+  color: $brand-green;
+}
+
+.red {
+  color: $brand-red;
+}
+
+.black {
+  color: $brand-black;
+}
+
+.lightGrey {
+  color: $brand-lightGrey;
+}
+
+.defaultGrey {
+  color: $brand-grey;
+}
+
+.darkGrey {
+  color: $brand-darkGrey;
+}
+
+.white {
+  color: white;
+}

--- a/src/components/ProgressBar/ProgressBar.module.scss
+++ b/src/components/ProgressBar/ProgressBar.module.scss
@@ -42,8 +42,6 @@ $progress-bar-height: $base-spacing * 0.75;
   100% { width: 100%; }
 }
 
-
-// Matches color prop for Text component. Perhaps global?
 .purple {
   color: $brand-purple;
 }

--- a/src/components/ProgressBar/ProgressBar.module.scss
+++ b/src/components/ProgressBar/ProgressBar.module.scss
@@ -6,7 +6,7 @@ $progress-bar-height: $base-spacing * 0.75;
   display: inline-flex;
   align-items: center;
   width: 100%;
-  min-width: 100px;
+  min-width: $base-spacing * 12;
 }
 
 .progressBar {

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -43,7 +43,7 @@ ProgressBar.propTypes = {
     'defaultGrey',
     'lightGrey',
     'darkGrey'
-  ]).isRequired
+  ])
 };
 
 ProgressBar.defaultProps = {

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './ProgressBar.module.scss';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { Text } from 'components';
+
+const ProgressBar = props => {
+  const { displayPercent, percent, color, className } = props;
+
+  return (
+    <div
+      className={`${className} ${styles.progressBarWrapper} ${styles[color]}`}
+    >
+      <div className={`${styles.progressBar}`}>
+        <div
+          className={`${styles.progressBarFillWidth}`}
+          style={{ width: `${percent}%` }}
+        >
+          <div className={`${styles.progressBarFill}`} />
+        </div>
+      </div>
+      <Text className={`${styles.percentage}`} weight="fontWeight-medium">
+        {`${percent}%`}
+      </Text>
+    </div>
+  );
+};
+
+ProgressBar.propTypes = {
+  className: PropTypes.string,
+  displayPercent: PropTypes.bool,
+  percent: PropTypes.number,
+  color: PropTypes.oneOf([
+    'purple',
+    'blue',
+    'orange',
+    'green',
+    'red',
+    'black',
+    'white',
+    'defaultGrey',
+    'lightGrey',
+    'darkGrey'
+  ]).isRequired
+};
+
+ProgressBar.defaultProps = {
+  percent: 0
+};
+
+export default ProgressBar;

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './ProgressBar.module.scss';
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { Text } from 'components';
 
 const ProgressBar = props => {
@@ -47,6 +46,7 @@ ProgressBar.propTypes = {
 };
 
 ProgressBar.defaultProps = {
+  displayPercent: true,
   percent: 0,
   color: 'purple'
 };

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -19,9 +19,11 @@ const ProgressBar = props => {
           <div className={`${styles.progressBarFill}`} />
         </div>
       </div>
-      <Text className={`${styles.percentage}`} weight="fontWeight-medium">
-        {`${percent}%`}
-      </Text>
+      {displayPercent && (
+        <Text className={`${styles.percentage}`} weight="fontWeight-medium">
+          {`${percent}%`}
+        </Text>
+      )}
     </div>
   );
 };
@@ -45,7 +47,8 @@ ProgressBar.propTypes = {
 };
 
 ProgressBar.defaultProps = {
-  percent: 0
+  percent: 0,
+  color: 'purple'
 };
 
 export default ProgressBar;

--- a/src/containers/Dashboard/Dashboard.module.scss
+++ b/src/containers/Dashboard/Dashboard.module.scss
@@ -101,13 +101,12 @@ $slider-height: calc(100vh - #{$header-height-sm});
 }
 
 .profileStrength {
-  min-height: $base-spacing * 2.5;
   display: flex;
   align-items: center;
   white-space: nowrap;
 }
 
 .profileStrengthProgress {
-  max-width: 300px;
+  max-width: $base-spacing * 36;
   margin: 0 $l-spacing 0 $m-spacing;
 }

--- a/src/containers/Dashboard/Dashboard.module.scss
+++ b/src/containers/Dashboard/Dashboard.module.scss
@@ -99,3 +99,15 @@ $slider-height: calc(100vh - #{$header-height-sm});
     text-align: left;
   }
 }
+
+.profileStrength {
+  min-height: $base-spacing * 2.5;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.profileStrengthProgress {
+  max-width: 300px;
+  margin: 0 $l-spacing 0 $m-spacing;
+}

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -11,7 +11,7 @@ import {
   SubmissionsPanel,
   UserStats
 } from 'containers';
-import { Text, PageBanner } from 'components';
+import { Text, PageBanner, ProgressBar } from 'components';
 import { getCurrentUserSelector } from 'public-modules/Authentication/selectors';
 import { profileStrengthSelector } from 'containers/Profile/selectors';
 import { actions as activityActions } from 'public-modules/Activity';
@@ -71,18 +71,25 @@ class DashboardComponent extends React.Component {
     const profileStrengthBanner =
       50 === 100 ? null : (
         <PageBanner wrapClass="pageWrapper-large">
-          <Text typeScale="Small" color="defaultGrey" inline>
-            Profile strength - {profileStrength} {/* hard number for now */}
-          </Text>
-          <Text
-            link
-            fontStyle="underline"
-            onClick={() => {
-              history.push('/settings');
-            }}
-          >
-            Edit profile
-          </Text>
+          <div className={`${styles.profileStrength}`}>
+            <Text typeScale="Small" color="defaultGrey" inline>
+              Profile strength
+            </Text>
+            <ProgressBar
+              className={`${styles.profileStrengthProgress}`}
+              color="purple"
+              percent={25}
+            />
+            <Text
+              link
+              fontStyle="underline"
+              onClick={() => {
+                history.push('/settings');
+              }}
+            >
+              Edit profile
+            </Text>
+          </div>
         </PageBanner>
       );
 

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -68,30 +68,29 @@ class DashboardComponent extends React.Component {
       arrows: false
     };
 
-    const profileStrengthBanner =
-      50 === 100 ? null : (
-        <PageBanner wrapClass="pageWrapper-large">
-          <div className={`${styles.profileStrength}`}>
-            <Text typeScale="Small" color="defaultGrey" inline>
-              Profile strength
-            </Text>
-            <ProgressBar
-              className={`${styles.profileStrengthProgress}`}
-              color="purple"
-              percent={25}
-            />
-            <Text
-              link
-              fontStyle="underline"
-              onClick={() => {
-                history.push('/settings');
-              }}
-            >
-              Edit profile
-            </Text>
-          </div>
-        </PageBanner>
-      );
+    const profileStrengthBanner = profileStrength < 100 && (
+      <PageBanner wrapClass="pageWrapper-large">
+        <div className={`${styles.profileStrength}`}>
+          <Text typeScale="Small" color="defaultGrey" inline>
+            Profile strength
+          </Text>
+          <ProgressBar
+            className={`${styles.profileStrengthProgress}`}
+            color="purple"
+            percent={profileStrength}
+          />
+          <Text
+            link
+            fontStyle="underline"
+            onClick={() => {
+              history.push('/settings');
+            }}
+          >
+            Edit profile
+          </Text>
+        </div>
+      </PageBanner>
+    );
 
     return (
       <div>
@@ -138,6 +137,7 @@ class DashboardComponent extends React.Component {
 const mapStateToProps = state => {
   const currentUser = getCurrentUserSelector(state);
   const { public_address } = currentUser;
+  console.log(currentUser);
 
   return {
     public_address,

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -61,7 +61,7 @@ class DashboardComponent extends React.Component {
   }
 
   render() {
-    const { profileStrength } = this.props;
+    const { profileStrength, history } = this.props;
 
     var settings = {
       dots: true,
@@ -70,11 +70,17 @@ class DashboardComponent extends React.Component {
 
     const profileStrengthBanner =
       50 === 100 ? null : (
-        <PageBanner size="large">
+        <PageBanner wrapClass="pageWrapper-large">
           <Text typeScale="Small" color="defaultGrey" inline>
             Profile strength - {profileStrength} {/* hard number for now */}
           </Text>
-          <Text src={'asdf'} fontStyle="underline" link>
+          <Text
+            link
+            fontStyle="underline"
+            onClick={() => {
+              history.push('/settings');
+            }}
+          >
             Edit profile
           </Text>
         </PageBanner>
@@ -125,8 +131,6 @@ class DashboardComponent extends React.Component {
 const mapStateToProps = state => {
   const currentUser = getCurrentUserSelector(state);
   const { public_address } = currentUser;
-
-  console.log('CURRENT USER', currentUser);
 
   return {
     public_address,

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -44,6 +44,10 @@ class DashboardComponent extends React.Component {
       setActiveSubmissionsTab
     } = props;
 
+    this.state = {
+      profileStrengthBannerOpen: true
+    };
+
     // load bounties panel
     resetState();
     addIssuerFilter(public_address);
@@ -69,7 +73,11 @@ class DashboardComponent extends React.Component {
     };
 
     const profileStrengthBanner = profileStrength < 100 && (
-      <PageBanner wrapClass="pageWrapper-large">
+      <PageBanner
+        wrapClass="pageWrapper-large"
+        visible={this.state.profileStrengthBannerOpen}
+        onClose={() => this.setState({ profileStrengthBannerOpen: false })}
+      >
         <div className={`${styles.profileStrength}`}>
           <Text typeScale="Small" color="defaultGrey" inline>
             Profile strength

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -137,7 +137,6 @@ class DashboardComponent extends React.Component {
 const mapStateToProps = state => {
   const currentUser = getCurrentUserSelector(state);
   const { public_address } = currentUser;
-  console.log(currentUser);
 
   return {
     public_address,

--- a/src/containers/Dashboard/index.js
+++ b/src/containers/Dashboard/index.js
@@ -11,7 +11,9 @@ import {
   SubmissionsPanel,
   UserStats
 } from 'containers';
+import { Text, PageBanner } from 'components';
 import { getCurrentUserSelector } from 'public-modules/Authentication/selectors';
+import { profileStrengthSelector } from 'containers/Profile/selectors';
 import { actions as activityActions } from 'public-modules/Activity';
 import { actions as bountiesActions } from 'public-modules/Bounties';
 import { actions as draftsActions } from 'public-modules/Drafts';
@@ -59,12 +61,28 @@ class DashboardComponent extends React.Component {
   }
 
   render() {
+    const { profileStrength } = this.props;
+
     var settings = {
       dots: true,
       arrows: false
     };
+
+    const profileStrengthBanner =
+      50 === 100 ? null : (
+        <PageBanner size="large">
+          <Text typeScale="Small" color="defaultGrey" inline>
+            Profile strength - {profileStrength} {/* hard number for now */}
+          </Text>
+          <Text src={'asdf'} fontStyle="underline" link>
+            Edit profile
+          </Text>
+        </PageBanner>
+      );
+
     return (
       <div>
+        {profileStrengthBanner}
         <div className={`pageWrapper-large ${styles.desktopContainer}`}>
           <UserStats />
           <div className={styles.panelContainer}>
@@ -108,8 +126,11 @@ const mapStateToProps = state => {
   const currentUser = getCurrentUserSelector(state);
   const { public_address } = currentUser;
 
+  console.log('CURRENT USER', currentUser);
+
   return {
-    public_address
+    public_address,
+    profileStrength: profileStrengthSelector(state)
   };
 };
 

--- a/src/containers/Profile/selectors.js
+++ b/src/containers/Profile/selectors.js
@@ -5,6 +5,8 @@ import { isEmpty } from 'lodash';
 export const profileUISelector = state => state.profileUI;
 
 const profileSections = [
+  // would there be a difference here between small and large for determining whether they've uploaded a profile pic?
+  ['small_profile_image_url'],
   ['name', 'organization', 'languages'],
   ['skills'],
   ['website', 'twitter', 'github', 'linkedin'],
@@ -16,13 +18,16 @@ export const profileStrengthSelector = createSelector(
   currentUser => {
     return Math.round(
       (profileSections.reduce((sectionsFilled, sectionFields) => {
-        return sectionsFilled +
-          sectionFields.reduce(
-            (fieldsFilled, field) => !isEmpty(field) || fieldsFilled,
+        return (
+          sectionsFilled +
+          (sectionFields.reduce(
+            (fieldsFilled, field) =>
+              !isEmpty(currentUser[field]) || fieldsFilled,
             false
           )
-          ? 1
-          : 0;
+            ? 1
+            : 0)
+        );
       }, 0) /
         profileSections.length) *
         100

--- a/src/containers/Profile/selectors.js
+++ b/src/containers/Profile/selectors.js
@@ -1,11 +1,10 @@
 import { getCurrentUserSelector } from 'public-modules/Authentication/selectors';
 import { createSelector } from 'reselect';
-import { isEmpty } from 'lodash';
+import { isEmpty, reduce } from 'lodash';
 
 export const profileUISelector = state => state.profileUI;
 
 const profileSections = [
-  // would there be a difference here between small and large for determining whether they've uploaded a profile pic?
   ['small_profile_image_url'],
   ['name', 'organization', 'languages'],
   ['skills'],
@@ -17,18 +16,24 @@ export const profileStrengthSelector = createSelector(
   getCurrentUserSelector,
   currentUser => {
     return Math.round(
-      (profileSections.reduce((sectionsFilled, sectionFields) => {
-        return (
-          sectionsFilled +
-          (sectionFields.reduce(
-            (fieldsFilled, field) =>
-              !isEmpty(currentUser[field]) || fieldsFilled,
-            false
-          )
-            ? 1
-            : 0)
-        );
-      }, 0) /
+      (reduce(
+        (sectionsFilled, sectionFields) => {
+          console.log(profileSections, sectionFields, sectionsFilled);
+          return (
+            sectionsFilled +
+            (reduce(
+              (fieldsFilled, field) =>
+                !isEmpty(currentUser[field]) || fieldsFilled,
+              false,
+              sectionFields
+            )
+              ? 1
+              : 0)
+          );
+        },
+        0,
+        profileSections
+      ) /
         profileSections.length) *
         100
     );

--- a/src/containers/Profile/selectors.js
+++ b/src/containers/Profile/selectors.js
@@ -1,1 +1,31 @@
+import { getCurrentUserSelector } from 'public-modules/Authentication/selectors';
+import { createSelector } from 'reselect';
+import { isEmpty } from 'lodash';
+
 export const profileUISelector = state => state.profileUI;
+
+const profileSections = [
+  ['name', 'organization', 'languages'],
+  ['skills'],
+  ['website', 'twitter', 'github', 'linkedin'],
+  ['email']
+];
+
+export const profileStrengthSelector = createSelector(
+  getCurrentUserSelector,
+  currentUser => {
+    return Math.round(
+      (profileSections.reduce((sectionsFilled, sectionFields) => {
+        return sectionsFilled +
+          sectionFields.reduce(
+            (fieldsFilled, field) => !isEmpty(field) || fieldsFilled,
+            false
+          )
+          ? 1
+          : 0;
+      }, 0) /
+        profileSections.length) *
+        100
+    );
+  }
+);

--- a/src/containers/Profile/selectors.js
+++ b/src/containers/Profile/selectors.js
@@ -18,7 +18,6 @@ export const profileStrengthSelector = createSelector(
     return Math.round(
       (reduce(
         (sectionsFilled, sectionFields) => {
-          console.log(profileSections, sectionFields, sectionsFilled);
           return (
             sectionsFilled +
             (reduce(

--- a/src/stories/PageBanner.stories.js
+++ b/src/stories/PageBanner.stories.js
@@ -26,12 +26,11 @@ storiesOf('PageBanner', module).add('PageBanner', () => (
         dismissable section. The banner can be configured to not be dismissable.
         A wrapping class can be provided in order to match the content's width
         to the wrapper of the page's content. The banner will always fill the
-        available width. Once a banner is dismissed it cannot be brought back.
-        The containing page can determine whether the banner shows at all by
-        conditionally rendering the component, but otherwise the open "state" of
-        the banner is managed by the component itself. The parent page can
-        perform actions when the banner is closed by using the
-        <code>onClose</code> prop.
+        available width. The parent page can perform actions when the banner is
+        closed by using the <code>onClose</code> prop. The banner close button
+        by itself does not dismiss, but requires the <code>visible</code> prop
+        to be set to false. Once a banner is dismissed it cannot be brought
+        back.
       </Text>
 
       <Text
@@ -123,7 +122,9 @@ storiesOf('PageBanner', module).add('PageBanner', () => (
         lineHeight="lineHeight-default"
       >
         The <code>onClose</code> prop takes a function that will be called when
-        the user dismisses the banner.
+        the user dismisses the banner. A parent component can use this callback
+        in order to set the <code>visible</code> prop to <code>false</code>
+        in order to dismiss the banner visually.
       </Text>
     </div>
 

--- a/src/stories/PageBanner.stories.js
+++ b/src/stories/PageBanner.stories.js
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { PageBanner, Text } from 'components';
+
+storiesOf('PageBanner', module).add('PageBanner', () => (
+  <div class="sb-page-wrapper">
+    <Text
+      className={'sb-component-group-heading'}
+      typeScale="h1"
+      color="purple"
+      weight="fontWeight-bold"
+    >
+      PageBanner
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      PageBanner component can take any content and display it as dismissable at
+      the top of a page. The containing page can hook into the close action to
+      perform any necessary changes. The banner can be configured to not be
+      dismissable. A wrapping class can be provided in order to match the
+      content's width to the wrapper of the page's content.
+    </Text>
+
+    <Text
+      className={'sb-component-group-subheading'}
+      typeScale="h3"
+      weight="fontWeight-bold"
+    >
+      Dismissability
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      The <code>dismissable</code> prop will determine whether the X button
+      appears and the banner can be closed.
+    </Text>
+
+    <div class="sb-component-container">
+      <PageBanner onClose={action('Banner dismissed')}>
+        <Text>Some content</Text>
+      </PageBanner>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner dismissable={false}>
+        <Text>Some content</Text>
+      </PageBanner>
+    </div>
+  </div>
+));

--- a/src/stories/PageBanner.stories.js
+++ b/src/stories/PageBanner.stories.js
@@ -3,57 +3,170 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { PageBanner, Text } from 'components';
+import { PageBanner, Text, Avatar } from 'components';
 
 storiesOf('PageBanner', module).add('PageBanner', () => (
-  <div class="sb-page-wrapper">
-    <Text
-      className={'sb-component-group-heading'}
-      typeScale="h1"
-      color="purple"
-      weight="fontWeight-bold"
-    >
-      PageBanner
-    </Text>
+  <div>
+    <div class="sb-page-wrapper">
+      <Text
+        className={'sb-component-group-heading'}
+        typeScale="h1"
+        color="purple"
+        weight="fontWeight-bold"
+      >
+        PageBanner
+      </Text>
 
-    <Text
-      className={'sb-component-group-description'}
-      typeScale="Body"
-      lineHeight="lineHeight-default"
-    >
-      PageBanner component can take any content and display it as dismissable at
-      the top of a page. The containing page can hook into the close action to
-      perform any necessary changes. The banner can be configured to not be
-      dismissable. A wrapping class can be provided in order to match the
-      content's width to the wrapper of the page's content.
-    </Text>
+      <Text
+        className={'sb-component-group-description'}
+        typeScale="Body"
+        lineHeight="lineHeight-default"
+      >
+        PageBanner component can take any content and display it as a
+        dismissable section. The banner can be configured to not be dismissable.
+        A wrapping class can be provided in order to match the content's width
+        to the wrapper of the page's content. The banner will always fill the
+        available width. Once a banner is dismissed it cannot be brought back.
+        The containing page can determine whether the banner shows at all by
+        conditionally rendering the component, but otherwise the open "state" of
+        the banner is managed by the component itself. The parent page can
+        perform actions when the banner is closed by using the
+        <code>onClose</code> prop.
+      </Text>
 
-    <Text
-      className={'sb-component-group-subheading'}
-      typeScale="h3"
-      weight="fontWeight-bold"
-    >
-      Dismissability
-    </Text>
+      <Text
+        className={'sb-component-group-subheading'}
+        typeScale="h3"
+        weight="fontWeight-bold"
+      >
+        Banner Sizing
+      </Text>
 
-    <Text
-      className={'sb-component-group-description'}
-      typeScale="Body"
-      lineHeight="lineHeight-default"
-    >
-      The <code>dismissable</code> prop will determine whether the X button
-      appears and the banner can be closed.
-    </Text>
+      <Text
+        className={'sb-component-group-description'}
+        typeScale="Body"
+        lineHeight="lineHeight-default"
+      >
+        The banner will change height appropriately based on the content.
+      </Text>
+    </div>
 
     <div class="sb-component-container">
-      <PageBanner onClose={action('Banner dismissed')}>
-        <Text>Some content</Text>
+      <PageBanner>
+        <Text>Single line content</Text>
+      </PageBanner>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner>
+        <Text>A banner</Text>
+        <Text>with more</Text>
+        <Text>Content</Text>
+      </PageBanner>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner>
+        <Avatar
+          size="large"
+          border
+          name="Simona Pop"
+          img="https://i.imgur.com/lhTwRZY.png"
+          address="0xe68f8C6AB137ecDGD5cbf131f74A584aD2fG294r"
+        />
+      </PageBanner>
+    </div>
+
+    <div class="sb-page-wrapper">
+      <Text
+        className={'sb-component-group-subheading'}
+        typeScale="h3"
+        weight="fontWeight-bold"
+      >
+        Dismissability
+      </Text>
+
+      <Text
+        className={'sb-component-group-description'}
+        typeScale="Body"
+        lineHeight="lineHeight-default"
+      >
+        The <code>dismissable</code> prop will determine whether the X button
+        appears and the banner can be closed.
+      </Text>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner>
+        <Text>Dismissable banner</Text>
       </PageBanner>
     </div>
 
     <div class="sb-component-container">
       <PageBanner dismissable={false}>
-        <Text>Some content</Text>
+        <Text>Non-dismissable banner</Text>
+      </PageBanner>
+    </div>
+
+    <div class="sb-page-wrapper">
+      <Text
+        className={'sb-component-group-subheading'}
+        typeScale="h3"
+        weight="fontWeight-bold"
+      >
+        OnClose Callback
+      </Text>
+
+      <Text
+        className={'sb-component-group-description'}
+        typeScale="Body"
+        lineHeight="lineHeight-default"
+      >
+        The <code>onClose</code> prop takes a function that will be called when
+        the user dismisses the banner.
+      </Text>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner onClose={action('Banner dismissed')}>
+        <Text>Action on banner dismiss</Text>
+      </PageBanner>
+    </div>
+
+    <div class="sb-page-wrapper">
+      <Text
+        className={'sb-component-group-subheading'}
+        typeScale="h3"
+        weight="fontWeight-bold"
+      >
+        Content Width
+      </Text>
+
+      <Text
+        className={'sb-component-group-description'}
+        typeScale="Body"
+        lineHeight="lineHeight-default"
+      >
+        The content width should match the width of the content on the page
+        where it is displayed. This can be accomplished using the
+        <code>wrapClass</code> prop to pass a class name which controls the
+        width and edge padding of the content. By default the wrapClass is
+        <code>pageWrapper</code>, but others can be used such as
+        <code>pageWrapper-large</code> which matches the Explorer dashboard. By
+        default on smaller screens the content is full width with 1rem edge
+        padding matching other components.
+      </Text>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner>
+        <Text>Default wrap class</Text>
+      </PageBanner>
+    </div>
+
+    <div class="sb-component-container">
+      <PageBanner wrapClass={'pageWrapper-large'}>
+        <Text>Larger wrap class</Text>
       </PageBanner>
     </div>
   </div>

--- a/src/stories/ProgressBar.stories.js
+++ b/src/stories/ProgressBar.stories.js
@@ -22,7 +22,10 @@ storiesOf('ProgressBar', module).add('ProgressBar', () => (
     >
       ProgressBar component takes <code>percent</code> as its primary prop to
       display an animated bar. It can also choose to display the percent
-      numerically, and is color configurable.
+      numerically, and is color configurable. The ProgressBar component will
+      fill the available width of its container and thus can be width controlled
+      with a parent container class or attaching a width-override class directly
+      with the <code>className</code> prop.
     </Text>
 
     <Text
@@ -77,7 +80,7 @@ storiesOf('ProgressBar', module).add('ProgressBar', () => (
     </Text>
 
     <div class="sb-component-group">
-      <ProgressBar displayPercent={false} percent={0} />
+      <ProgressBar displayPercent={false} percent={50} />
     </div>
 
     <Text
@@ -95,10 +98,10 @@ storiesOf('ProgressBar', module).add('ProgressBar', () => (
     >
       The <code>color</code> prop determines the color of the progress bar. It's
       values match those used elsewhere and can be one of the following
-      <code>
-        'purple', 'blue', 'orange', 'green', 'red', 'black', 'white',
-        'defaultGrey', 'lightGrey', 'darkGrey'
-      </code>
+      <code>'purple'</code> <code>'blue'</code> <code>'orange'</code>
+      <code>'green'</code> <code>'red'</code> <code>'black'</code>
+      <code>'white'</code> <code>'defaultGrey'</code> <code>'lightGrey'</code>
+      <code>'darkGrey'</code>
       The default value is <code>'purple'</code>
     </Text>
 
@@ -114,6 +117,30 @@ storiesOf('ProgressBar', module).add('ProgressBar', () => (
       </div>
       <div class="sb-component-container">
         <ProgressBar percent={50} color={'darkGrey'} />
+      </div>
+    </div>
+
+    <Text
+      className={'sb-component-group-subheading'}
+      typeScale="h3"
+      weight="fontWeight-bold"
+    >
+      Controlling Width
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      The component fills the available space but can be controlled with a
+      parent container width/max-width or a width-override class using the
+      <code>className</code> prop. The ProgressBar has a minimum width of 6rem.
+    </Text>
+
+    <div class="sb-component-group">
+      <div class="sb-component-container" style={{ width: '75%' }}>
+        <ProgressBar percent={50} />
       </div>
     </div>
   </div>

--- a/src/stories/ProgressBar.stories.js
+++ b/src/stories/ProgressBar.stories.js
@@ -1,0 +1,120 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
+import { Text, ProgressBar } from 'components';
+
+storiesOf('ProgressBar', module).add('ProgressBar', () => (
+  <div class="sb-page-wrapper">
+    <Text
+      className={'sb-component-group-heading'}
+      typeScale="h1"
+      color="purple"
+      weight="fontWeight-bold"
+    >
+      ProgressBar
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      ProgressBar component takes <code>percent</code> as its primary prop to
+      display an animated bar. It can also choose to display the percent
+      numerically, and is color configurable.
+    </Text>
+
+    <Text
+      className={'sb-component-group-subheading'}
+      typeScale="h3"
+      weight="fontWeight-bold"
+    >
+      Percent
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      The <code>percent</code> prop determines the length of the colored
+      progress bar. The bar animates from 0 to the percent on component mount.
+      It will also animate between percentages should the prop change after
+      mounting.
+    </Text>
+
+    <div class="sb-component-group">
+      <div class="sb-component-container">
+        <ProgressBar percent={0} />
+      </div>
+      <div class="sb-component-container">
+        <ProgressBar percent={33} />
+      </div>
+      <div class="sb-component-container">
+        <ProgressBar percent={66} />
+      </div>
+      <div class="sb-component-container">
+        <ProgressBar percent={100} />
+      </div>
+    </div>
+
+    <Text
+      className={'sb-component-group-subheading'}
+      typeScale="h3"
+      weight="fontWeight-bold"
+    >
+      Display Percent
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      The <code>displayPercent</code> prop determines whether to show the
+      percentage as a number next to the bar.
+    </Text>
+
+    <div class="sb-component-group">
+      <ProgressBar displayPercent={false} percent={0} />
+    </div>
+
+    <Text
+      className={'sb-component-group-subheading'}
+      typeScale="h3"
+      weight="fontWeight-bold"
+    >
+      Colors
+    </Text>
+
+    <Text
+      className={'sb-component-group-description'}
+      typeScale="Body"
+      lineHeight="lineHeight-default"
+    >
+      The <code>color</code> prop determines the color of the progress bar. It's
+      values match those used elsewhere and can be one of the following
+      <code>
+        'purple', 'blue', 'orange', 'green', 'red', 'black', 'white',
+        'defaultGrey', 'lightGrey', 'darkGrey'
+      </code>
+      The default value is <code>'purple'</code>
+    </Text>
+
+    <div class="sb-component-group">
+      <div class="sb-component-container">
+        <ProgressBar percent={50} color={'blue'} />
+      </div>
+      <div class="sb-component-container">
+        <ProgressBar percent={50} color={'green'} />
+      </div>
+      <div class="sb-component-container">
+        <ProgressBar percent={50} color={'orange'} />
+      </div>
+      <div class="sb-component-container">
+        <ProgressBar percent={50} color={'darkGrey'} />
+      </div>
+    </div>
+  </div>
+));


### PR DESCRIPTION
Hi guys!

Here's the components and updates required for the profile strength banner on the dashboard page. Here I'll list some of my considerations and decisions, and I'll try to add some GitHub comments on lines about questions I may have had.

### Decisions
#### PageBanner
This component has essentially two states: displayed and dismissed. I took the route that the PageBanner should be the one to manage whether it is open or closed, with the containing page/component being able to choose whether it shows up at all just using conditional rendering. This simplifies its usage, particularly in cases where the banner is always in existence (banner is dismissable and always on page means the parent doesn't have to manage its open/close state). For instance, on the dashboard, the profile strength banner is rendered conditionally based on strength < 100, but once rendered its open/closed state and animation are controlled completely by the banner itself.

The provided mock was a single line, but the banner can hold content of various heights (see stories).

Another consideration was the different page content width sizes and the expectation that the content + X button of the banner should match. Here, I allowed a wrapClass to be passed in which defines this behavior and can match it to existing and future pages should more wrapper classes be added. For instance, it uses pageWrapper-large on the dashboard to match the page's content width.

#### ProgressBar
The progress bar in order to be used as freely as possible includes just the bar and the percentage. It fills its parent by default, but can have classes added to override or a parent element class to control its width. Its color is configurable with the same props as other color-configurable components, but both the bar and the percent text can inherit colors if no prop is provided.

#### Dashboard Profile Strength
Because the profile strength banner for now is only present on the Dashboard, I chose to use the PageBanner and ProgressBar components here in addition to some other classes. If placing it on other pages, it could easily be abstracted to a higher level ProfileStrengthBanner component or something similar to simplify reuse.

#### Profile Strength Calculation
The percentage is based on the percentage of _sections_ (of 5 current) that are completed. So if GitHub username is filled, the Elsewhere section is considered complete. This could be adjusted to make each count as a portion of the section, but would lead to people without any intention of ever getting a twitter always seeing the banner.

The calculation is done using a redux selector which updates when currentUser changes. This is currently in the profile selectors file; not convinced this is where it belongs :)