### PR TITLE
Add another deploy choice that avoids staging: deploy-all-production

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
     "deploy-prague": "APP_SETTINGS_FILE=prague_settings APP_LOGO=logo npm run build && aws s3 sync build/. s3://prague.bounties.network --acl public-read --exclude index.html --cache-control max-age=31536000 && aws s3 cp build/index.html s3://prague.bounties.network --acl public-read --cache-control 'no-cache, no-store, must-revalidate'",
     "deploy-staging": "APP_SETTINGS_FILE=staging_settings APP_LOGO=logo npm run build && aws s3 sync build/. s3://staging.bounties.network --acl public-read --exclude index.html --cache-control max-age=31536000 && aws s3 cp build/index.html s3://staging.bounties.network --acl public-read --cache-control 'no-cache, no-store, must-revalidate'",
     "deploy-production": "APP_SETTINGS_FILE=production_settings APP_LOGO=logo npm run build && aws s3 sync build/. s3://explorer.bounties.network --acl public-read --exclude index.html --cache-control max-age=31536000 && aws s3 cp build/index.html s3://explorer.bounties.network --acl public-read --cache-control 'no-cache, no-store, must-revalidate'",
-    "deploy-all": "npm run deploy-berlin && npm run deploy-hiring && npm run deploy-bees && npm run deploy-staging && npm run deploy-production && npm run deploy-sf && npm run deploy-prague"
+    "deploy-all": "npm run deploy-berlin && npm run deploy-hiring && npm run deploy-bees && npm run deploy-staging && npm run deploy-production && npm run deploy-sf && npm run deploy-prague",
+    "deploy-all-production": "npm run deploy-production && npm run deploy-berlin && npm run deploy-hiring && npm run deploy-bees && npm run deploy-sf && npm run deploy-prague"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
@villanuevawill 

Simply add a deploy command that skips staging, so we can keep in-development builds there without overwriting when we want to deploy to all production environments. 