### PR TITLE
Fixed edge/ie issue that was breaking javascript

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -14,6 +14,7 @@ require('whatwg-fetch');
 // Object.assign() is commonly used with React.
 // It will use the native implementation if it's present and isn't buggy.
 Object.assign = require('object-assign');
+Array.from = require('array-from');
 
 // In tests, polyfill requestAnimationFrame since jsdom doesn't provide it yet.
 // We don't polyfill it in the browser--this is user's responsibility.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/fontawesome-pro-solid": "^5.0.13",
     "@fortawesome/fontawesome-svg-core": "^1.2.0",
     "@fortawesome/react-fontawesome": "0.0.20",
+    "array-from": "^2.1.1",
     "autoprefixer": "7.1.6",
     "axios": "^0.18.0",
     "babel-core": "6.26.0",

--- a/src/explorer-components/BountyCard/index.js
+++ b/src/explorer-components/BountyCard/index.js
@@ -8,6 +8,7 @@ import { EXPIRED } from 'public-modules/Bounty/constants';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { Card, Text, Pill } from 'components';
 import { Currency, LinkedAvatar } from 'explorer-components';
+import { scrollToTop } from 'utils/helpers';
 
 const BountyCard = props => {
   const {
@@ -73,9 +74,7 @@ const BountyCard = props => {
                 address={address}
                 hash={address}
                 to={`/profile/${address}`}
-                onClick={() =>
-                  document.getElementsByClassName('page-body')[0].scrollTo(0, 0)
-                }
+                onClick={() => scrollToTop()}
                 size="small"
               />
             </div>

--- a/src/layout/App/index.js
+++ b/src/layout/App/index.js
@@ -63,7 +63,7 @@ class HeaderComponent extends React.Component {
     } = this.props;
 
     if (prevProps.location.pathname !== pathname) {
-      document.getElementsByClassName('page-body')[0].scrollTo(0, 0);
+      scrollToTop();
       this.setState({ showMobileSidebar: false });
     }
   }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -88,7 +88,12 @@ export function getMobileOperatingSystem() {
 }
 
 export function scrollToTop() {
-  document.getElementsByClassName('page-body')[0].scrollTo(0, 0);
+  const pageBody = document.getElementsByClassName('page-body')[0];
+  if (pageBody.scrollTo) {
+    pageBody.scrollTo(0, 0);
+  } else {
+    pageBody.scrollTop = 0;
+  }
 }
 
 export function isNumber(n) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,6 +533,10 @@ array-flatten@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
 
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+
 array-includes@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"


### PR DESCRIPTION
Edge and older versions of IE use scrollTop = 0 vs the function call on scrollTo()
This fixes the issues where we broke on those browsers.