### PR TITLE
Modal lock issue resolved.

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -192,7 +192,7 @@ class Modal extends React.Component {
   };
 
   componentWillUnmount() {
-    const { fixed } = this.props;
+    const { fixed, visible } = this.props;
 
     const currentModals = document.getElementsByClassName('modal-visible');
     if (!fixed) {
@@ -202,7 +202,7 @@ class Modal extends React.Component {
       }
       document.body.classList.remove('modal-open');
     }
-    if (currentModals && currentModals.length) {
+    if (currentModals && currentModals.length > 1 && visible) {
       return null;
     }
     document.body.className = '';


### PR DESCRIPTION
Modal logic is fairly complex dealing with animations. This makes sure that if a modal is unmounting and it is the last VISIBLE modal, the modal-open class will be removed properly from the page body.