### PR TITLE
Remove berlin

### DIFF
--- a/src/public-modules/production_settings.json
+++ b/src/public-modules/production_settings.json
@@ -1,6 +1,6 @@
 {
   "platforms": {
-    "bounties-network": ["bounties-network", "sf", "berlin", "prague"],
+    "bounties-network": ["bounties-network", "sf", "prague"],
     "gitcoin": ["gitcoin"]
   },
   "postingPlatform": "bounties-network",


### PR DESCRIPTION
@c-o-l-o-r  this removes berlin. We originally talked about only having valued bounties ont he main explorer. Berlin coin had no value.