### PR TITLE
Manages new EIP-1102 privacy web3 injection rules

### DIFF
--- a/src/containers/Login/LoginLock.js
+++ b/src/containers/Login/LoginLock.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -20,67 +20,73 @@ import {
   hasWalletSelector
 } from 'public-modules/Client/selectors';
 
-const LoginLockComponent = props => {
-  const {
-    walletLocked,
-    walletAddress,
-    userAddress,
-    img,
-    logout,
-    loggingOut,
-    resetLogoutState,
-    network,
-    isCorrectNetwork,
-    error
-  } = props;
-
-  const config = {
-    showUnlockWallet: false,
-    showError: false,
-    showMismatch: false,
-    showWrongNetwork: false
-  };
-
-  if (walletLocked || !walletAddress) {
-    config.showUnlockWallet = true;
-  } else if (error) {
-    config.showError = true;
-  } else if (!isCorrectNetwork) {
-    config.showWrongNetwork = true;
-  } else if (
-    userAddress &&
-    userAddress.toLowerCase() !== walletAddress.toLowerCase()
-  ) {
-    config.showMismatch = true;
+class LoginLockComponent extends Component {
+  componentDidMount() {
+    window.ethereum.enable();
   }
 
-  return (
-    <React.Fragment>
-      <UnlockWallet
-        visible={config.showUnlockWallet}
-        pageLevel
-        closable={false}
-      />
-      <WrongNetwork
-        visible={config.showWrongNetwork}
-        pageLevel
-        network={network}
-        closable={false}
-      />
-      <ErrorModal visible={config.showError} onClose={resetLogoutState} />
-      <AddressMismatch
-        closable={false}
-        visible={config.showMismatch}
-        currentAddress={walletAddress}
-        previousAddress={userAddress}
-        img={img}
-        logout={logout}
-        loggingOut={loggingOut}
-        pageLevel
-      />
-    </React.Fragment>
-  );
-};
+  render() {
+    const {
+      walletLocked,
+      walletAddress,
+      userAddress,
+      img,
+      logout,
+      loggingOut,
+      resetLogoutState,
+      network,
+      isCorrectNetwork,
+      error
+    } = this.props;
+
+    const config = {
+      showUnlockWallet: false,
+      showError: false,
+      showMismatch: false,
+      showWrongNetwork: false
+    };
+
+    if (walletLocked || !walletAddress) {
+      config.showUnlockWallet = true;
+    } else if (error) {
+      config.showError = true;
+    } else if (!isCorrectNetwork) {
+      config.showWrongNetwork = true;
+    } else if (
+      userAddress &&
+      userAddress.toLowerCase() !== walletAddress.toLowerCase()
+    ) {
+      config.showMismatch = true;
+    }
+
+    return (
+      <React.Fragment>
+        <UnlockWallet
+          visible={config.showUnlockWallet}
+          pageLevel
+          closable={false}
+        />
+        <WrongNetwork
+          visible={config.showWrongNetwork}
+          pageLevel
+          network={network}
+          closable={false}
+        />
+        <ErrorModal visible={config.showError} onClose={resetLogoutState} />
+        <AddressMismatch
+          closable={false}
+          visible={config.showMismatch}
+          currentAddress={walletAddress}
+          previousAddress={userAddress}
+          img={img}
+          logout={logout}
+          loggingOut={loggingOut}
+          pageLevel
+        />
+      </React.Fragment>
+    );
+  }
+}
 
 const mapStateToProps = state => {
   const user = getCurrentUserSelector(state);

--- a/src/containers/Login/LoginLock.js
+++ b/src/containers/Login/LoginLock.js
@@ -22,7 +22,9 @@ import {
 
 class LoginLockComponent extends Component {
   componentDidMount() {
-    window.ethereum.enable();
+    if (window.ethereum) {
+      window.ethereum.enable();
+    }
   }
 
   render() {

--- a/src/containers/Login/components/UnlockWallet.js
+++ b/src/containers/Login/components/UnlockWallet.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import config from 'public-modules/config';
 import { Modal, Text, Button } from 'components';
 
 const UnlockWallet = props => {
@@ -15,17 +16,18 @@ const UnlockWallet = props => {
       fixed={!pageLevel}
     >
       <Modal.Header closable={closable} icon={['fal', 'unlock']}>
-        <Modal.Message>Please unlock your secure wallet</Modal.Message>
+        <Modal.Message>Secure Wallet Access</Modal.Message>
       </Modal.Header>
       <Modal.Body>
         <Modal.Description>
-          You&#39;ll need to log in to your secure wallet account (e.g.
+          You&#39;ll need to log in and/or grant access to your secure wallet
+          (e.g.
           <Text weight="fontWeight-bold" inline>
             {' '}
             MetaMask
           </Text>
-          ) in order to access {pageLevel ? 'parts of the ' : ''}the Bounties
-          Network.
+          ) in order to use {pageLevel ? 'parts of ' : ''}
+          {config.networkName}
         </Modal.Description>
       </Modal.Body>
       {closable && (

--- a/src/containers/Login/index.js
+++ b/src/containers/Login/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -24,74 +24,82 @@ import {
   hasWalletSelector
 } from 'public-modules/Client/selectors';
 
-const LoginComponent = props => {
-  const {
-    visible,
-    stage,
-    hasWallet,
-    walletLocked,
-    showLogin,
-    login,
-    signingIn,
-    resetLoginState,
-    resetLogoutState,
-    loginError,
-    logoutError,
-    loggedIn
-  } = props;
-
-  const config = {
-    showWalletRequired: false,
-    showUnlockWallet: false,
-    showErrorModal: false,
-    showSigningIn: false,
-    showProfileDetails: false,
-    showSignIn: false
-  };
-
-  if (visible) {
-    if (!hasWallet) {
-      config.showWalletRequired = true;
-    } else if (walletLocked) {
-      config.showUnlockWallet = true;
-    } else if (loginError || logoutError) {
-      config.showErrorModal = true;
-    } else if (stage === 'profile') {
-      config.showProfileDetails = true;
-    } else if (signingIn || loggedIn) {
-      config.showSigningIn = true;
-    } else {
-      config.showSignIn = true;
+class LoginComponent extends Component {
+  componentDidUpdate(prevProps) {
+    if (!prevProps.visible && this.props.visible && window.ethereum) {
+      window.ethereum.enable();
     }
   }
 
-  return (
-    <React.Fragment>
-      <WalletRequired
-        visible={config.showWalletRequired}
-        onClose={() => showLogin(false)}
-      />
-      <UnlockWallet
-        visible={config.showUnlockWallet}
-        onClose={() => showLogin(false)}
-      />
-      <ErrorModal
-        visible={config.showErrorModal}
-        onClose={loginError ? resetLoginState : resetLogoutState}
-      />
-      <SigningIn visible={config.showSigningIn} />
-      <AddProfileDetails
-        visible={config.showProfileDetails}
-        onClose={() => showLogin(false)}
-      />
-      <SignIn
-        visible={config.showSignIn}
-        onClose={() => showLogin(false)}
-        signIn={login}
-      />
-    </React.Fragment>
-  );
-};
+  render() {
+    const {
+      visible,
+      stage,
+      hasWallet,
+      walletLocked,
+      showLogin,
+      login,
+      signingIn,
+      resetLoginState,
+      resetLogoutState,
+      loginError,
+      logoutError,
+      loggedIn
+    } = this.props;
+
+    const config = {
+      showWalletRequired: false,
+      showUnlockWallet: false,
+      showErrorModal: false,
+      showSigningIn: false,
+      showProfileDetails: false,
+      showSignIn: false
+    };
+
+    if (visible) {
+      if (!hasWallet) {
+        config.showWalletRequired = true;
+      } else if (walletLocked) {
+        config.showUnlockWallet = true;
+      } else if (loginError || logoutError) {
+        config.showErrorModal = true;
+      } else if (stage === 'profile') {
+        config.showProfileDetails = true;
+      } else if (signingIn || loggedIn) {
+        config.showSigningIn = true;
+      } else {
+        config.showSignIn = true;
+      }
+    }
+
+    return (
+      <React.Fragment>
+        <WalletRequired
+          visible={config.showWalletRequired}
+          onClose={() => showLogin(false)}
+        />
+        <UnlockWallet
+          visible={config.showUnlockWallet}
+          onClose={() => showLogin(false)}
+        />
+        <ErrorModal
+          visible={config.showErrorModal}
+          onClose={loginError ? resetLoginState : resetLogoutState}
+        />
+        <SigningIn visible={config.showSigningIn} />
+        <AddProfileDetails
+          visible={config.showProfileDetails}
+          onClose={() => showLogin(false)}
+        />
+        <SignIn
+          visible={config.showSignIn}
+          onClose={() => showLogin(false)}
+          signIn={login}
+        />
+      </React.Fragment>
+    );
+  }
+}
 
 const mapStateToProps = state => {
   const rootLogin = rootLoginSelector(state);

--- a/src/hocs/FunctionalLoginLock.js
+++ b/src/hocs/FunctionalLoginLock.js
@@ -36,6 +36,15 @@ function FunctionalLoginLockHOC(config, WrappedComponent) {
     };
 
     componentDidUpdate(prevProps) {
+      if (
+        !prevProps.visible &&
+        this.props.visible &&
+        this.props.walletLocked &&
+        window.ethereum
+      ) {
+        window.ethereum.enable();
+      }
+
       if (!prevProps.callbackCanTrigger && this.props.callbackCanTrigger) {
         this.props.showFunctionalLock(false);
         this.state.onConfirm();

--- a/src/public-modules/Client/sagas.js
+++ b/src/public-modules/Client/sagas.js
@@ -69,7 +69,7 @@ export function* getWeb3Client() {
     yield put(setHasWallet(hasWallet));
   }
   if (hasWallet) {
-    web3.setProvider(window.web3.currentProvider);
+    web3.setProvider(window.ethereum || window.web3.currentProvider);
     proxiedWeb3 = new Proxy(web3, proxiedWeb3Handler);
     isLocked = yield call(isWalletLocked);
   }


### PR DESCRIPTION
We originally had modals set up for this, but it became more complex.
@corwinharrell there is no way to know if a person's wallet is locked or if they have not given approval.

In this case, any time the (Your wallet is locked) dialogue shows, I just automate showing the metamask approval request. If they reject, the wallet is locked modal stays.

The other alternative... would be to show the metamask request modal any time a transaciton request or login request comes up. If they accept it (or they have preivously accepted), then the first modal shows. If not, then no modals show. However, metamask can be slow at times and it may seem choppy. Additionally, we can't have consistency with the locked pages (dashboard or settings), whereas the other solution keeps everything consistent.