### PR TITLE
Quickfix: Expand email validation to match .network addresses

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -41,7 +41,7 @@ const number = value =>
   value && isNaN(Number(value)) ? 'Must be a number' : undefined;
 
 const email = value =>
-  !value || !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
+  !value || !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,7}$/i.test(value)
     ? 'Invalid email address'
     : undefined;
 


### PR DESCRIPTION
- Go from 4 to 7 characters for the email validation regex