### PR TITLE
This fixes the event emitter leak issue.

### DIFF
--- a/src/public-modules/Client/sagas.js
+++ b/src/public-modules/Client/sagas.js
@@ -70,7 +70,9 @@ export function* getWeb3Client() {
     yield put(setHasWallet(hasWallet));
   }
   if (hasWallet) {
-    web3.setProvider(window.ethereum || window.web3.currentProvider);
+    if (!proxiedWeb3) {
+      web3.setProvider(window.ethereum || window.web3.currentProvider);
+    }
     proxiedWeb3 = new Proxy(web3, proxiedWeb3Handler);
     isLocked = yield call(isWalletLocked);
   }


### PR DESCRIPTION
Fixes, `Error: Possible EventEmitter memory leak detected. 101 data listeners added. Use emitter.setMaxListeners() to increase limit` caused by rebinding the web3 instance repeatedly to metamask which attaches 10 event listeners to. (this adds 10 per second until it is overloaded)