### PR TITLE
add colorado to main explorer

### DIFF
--- a/src/public-modules/production_settings.json
+++ b/src/public-modules/production_settings.json
@@ -1,6 +1,6 @@
 {
   "platforms": {
-    "bounties-network": ["bounties-network", "sf", "prague"],
+    "bounties-network": ["bounties-network", "sf", "prague", "colorado"],
     "gitcoin": ["gitcoin"]
   },
   "postingPlatform": "bounties-network",


### PR DESCRIPTION
This will make colorado bounties appear on the main explorer in addition to the subnetwork.