### PR TITLE
Stop 401s recording as API errors

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -57,6 +57,7 @@ const GET_OPTIONS = {
 function handleError(err) {
   const error = new Error();
   error.errorStatus = '';
+
   if (err.response) {
     const response = err.response;
     if (
@@ -64,7 +65,7 @@ function handleError(err) {
       response.status === HTTP_403_FORBIDDEN
     ) {
       rollbar.warning('User session expired: relogin');
-      // include redirect-type logic in here
+      throw error;
     }
 
     if (response.status >= HTTP_500_INTERNAL_SERVER_ERROR) {


### PR DESCRIPTION
This should stop 401s for coming in as errors to rollbar.