### PR TITLE
Add profile icon to second profile details modal

### DIFF
--- a/src/containers/Login/components/AddProfileDetails.js
+++ b/src/containers/Login/components/AddProfileDetails.js
@@ -53,7 +53,7 @@ class AddProfileDetails extends React.Component {
 
     return (
       <Modal visible={visible} size="small" dismissable onClose={this.onClose}>
-        <Modal.Header closable icon={['fal', 'id-card-alt']}>
+        <Modal.Header closable icon="profile">
           <Modal.Heading>Profile Details</Modal.Heading>
         </Modal.Header>
         <Modal.Body>


### PR DESCRIPTION
There were two instances of modals inside this file and I missed updating the second one:

<img width="740" alt="Screen Shot 2019-06-08 at 6 11 05 PM" src="https://user-images.githubusercontent.com/5934188/59152748-caeeb300-8a18-11e9-9b83-6948785b0465.png">
