### PR TITLE
Simplify ratings modal

### DIFF
--- a/src/containers/Bounty/components/modals/IssueRatingFormModal/IssueRatingFormModal.module.scss
+++ b/src/containers/Bounty/components/modals/IssueRatingFormModal/IssueRatingFormModal.module.scss
@@ -1,35 +1,12 @@
-@import "~styles/variables.scss";
+@import '~styles/variables.scss';
 
-.inputGroup {
-  margin-top: $xxl-spacing;
-}
-
-.bountyInfoContainer {
-  margin: $xl-spacing;
-  margin-bottom: $xxl-spacing * 2;
-}
-
-.bountyInfo {
-  position: relative;
-  padding: $m-spacing;
-  border: $base-border;
-  border-radius: $base-border-radius;
-  box-shadow: $base-box-shadow;
-
-  .pill {
-    line-height: 1;
-    position: absolute;
-    top: -10px;
-    left: -10px;
-  }
+.inputGroup:last-child {
+  margin-top: $xl-spacing;
 }
 
 .rowText {
   display: flex;
   justify-content: space-between;
-}
-
-.detailsGroup {
 }
 
 .review {

--- a/src/containers/Bounty/components/modals/IssueRatingFormModal/index.js
+++ b/src/containers/Bounty/components/modals/IssueRatingFormModal/index.js
@@ -81,7 +81,6 @@ const IssueRatingFormModalComponent = props => {
         size="medium"
       >
         <Modal.Header closable={true}>
-          <BountyDetails bounty={bounty} />
           <Modal.Heading>Rate {type}</Modal.Heading>
           <Modal.Description>
             {messageTemplate[type][0]}

--- a/src/containers/Bounty/components/modals/IssueRatingFormModal/index.js
+++ b/src/containers/Bounty/components/modals/IssueRatingFormModal/index.js
@@ -11,7 +11,6 @@ import { FormTextbox, FormRating } from 'form-components';
 import { actions as reviewActions } from 'public-modules/Review';
 import { rootReviewSelector } from 'public-modules/Review/selectors';
 import { ratingModalSelector } from 'containers/Bounty/selectors';
-import BountyDetails from './BountyDetails';
 
 const messageTemplate = {
   issuer: [


### PR DESCRIPTION
- Remove bounty preview card in order to simplify the ratings modal as users felt they were hindered by the amount of content in this modal instance and important information was hidden below the "fold" on small screens

<img width="895" alt="Screen Shot 2019-06-13 at 3 14 15 PM" src="https://user-images.githubusercontent.com/5934188/59461167-c0546500-8dee-11e9-953e-4e5227b80127.png">
